### PR TITLE
Update Firestore DocumentSnapshot to return Swift dictionary

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -676,7 +676,7 @@ public class DocumentSnapshot {
 
     public func data() -> [String: Any] {
         if let data = doc.getData() {
-            return Dictionary(data)
+            return deepSwift(map: data)
         } else {
             return [:]
         }


### PR DESCRIPTION
DocumentSnapshot.data() now returns valid Swift-typed dictionary