### PR TITLE
Add support for Firebase Auth anonymous sign-in

### DIFF
--- a/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
+++ b/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
@@ -55,6 +55,11 @@ public final class Auth {
 		// SKIP NOWARN
 		try await platformValue.sendPasswordResetEmail(email).await()
 	}
+
+	public func signInAnonymously() async throws -> AuthDataResult {
+		let result = try await platformValue.signInAnonymously().await()
+		return AuthDataResult(result)
+	}
 }
 
 public class AuthDataResult: KotlinConverting<com.google.firebase.auth.AuthResult> {


### PR DESCRIPTION
Add support for Firebase anonymous sign-in.

* Add `signInAnonymously` method to the `Auth` class in `Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift`.
* Implement the method to call `signInAnonymously` on the `platformValue`.
* Return an `AuthDataResult` from the method.

