### PR TITLE
Add start(afterDocument:) method for pagination support

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -371,6 +371,10 @@ public class Query: KotlinConverting<com.google.firebase.firestore.Query> {
         Query(query: query.whereArrayContainsAny(field.fieldPath, arrayContainsAny.kotlin()))
     }
 
+    public func start(afterDocument: DocumentSnapshot) -> Query {
+        Query(query: query.startAfter(afterDocument.kotlin()))
+    }
+
     public func addSnapshotListener(_ listener: @escaping (QuerySnapshot?, Error?) -> ()) -> ListenerRegistration {
         ListenerRegistration(reg: query.addSnapshotListener { snapshot, error in
             let qs: QuerySnapshot? = snapshot == nil ? nil : QuerySnapshot(snap: snapshot!)


### PR DESCRIPTION
- Added `start(afterDocument:)` to Query class for easier pagination after a specified document.