### PR TITLE
Add API to delete storage files

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -64,7 +64,6 @@ public final class Firestore: KotlinConverting<com.google.firebase.firestore.Fir
 //    }
 
     public func getQuery(named name: String) async -> Query? {
-        // SKIP NOWARN
         guard let query = store.getNamedQuery(name).await() else {
             return nil
         }

--- a/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
+++ b/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
@@ -192,8 +192,7 @@ public class StorageReference: KotlinConverting<com.google.firebase.storage.Stor
     }
 
     public func downloadURL() async throws -> URL {
-        // SKIP NOWARN
-        let uri: android.net.Uri = try await platformValue.downloadUrl.await()
+        let uri: android.net.Uri = platformValue.downloadUrl.await()
         return URL(string: uri.toString())!
     }
 
@@ -226,6 +225,20 @@ public class StorageReference: KotlinConverting<com.google.firebase.storage.Stor
         }
     }
 
+    public func delete(completion: (((any Error)?) -> Void)?) {
+      Task {
+        do {
+          platformValue.delete().await()
+          completion?(nil)
+        } catch {
+          completion?(error)
+        }
+      }
+    }
+
+    public func delete() async throws {
+        platformValue.delete().await()
+    }
 }
 
 #endif


### PR DESCRIPTION
Exposed both the async and non-async versions of `delete` on a Firebase storage reference.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

