### PR TITLE
Add storage URL helpers and fix metadata error

### DIFF
--- a/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
+++ b/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
@@ -26,6 +26,14 @@ public final class Storage {
         Storage(com.google.firebase.storage.FirebaseStorage.getInstance(app.app))
     }
 
+    public static func storage(url: String) -> Storage {
+        Storage(com.google.firebase.storage.FirebaseStorage.getInstance(url))
+    }
+
+    public static func storage(app: FirebaseApp, url: String) -> Storage {
+        Storage(com.google.firebase.storage.FirebaseStorage.getInstance(app.app, url))
+    }
+
     public var app: FirebaseApp {
         FirebaseApp(app: platformValue.getApp())
     }

--- a/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
+++ b/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
@@ -246,7 +246,7 @@ public class StorageReference: KotlinConverting<com.google.firebase.storage.Stor
     public func putFile(from fileURL: URL, metadata: StorageMetadata? = nil, completion: (_: StorageMetadata?, _: Error?) -> Void = { _, _ in }) -> StorageUploadTask {
         let fileURI: android.net.Uri = android.net.Uri.parse(fileURL.kotlin().toString())
 
-        let uploadTask = platformValue.putFile(fileURI, metadata?.platformValue, nil)
+        let uploadTask = metadata == nil ? platformValue.putFile(fileURI) : platformValue.putFile(fileURI, metadata!.platformValue, nil)
         uploadTask.addOnFailureListener { exception in
             completion(nil, ErrorException(exception))
         }.addOnSuccessListener { taskSnapshot in

--- a/Tests/SkipFirebaseStorageTests/SkipFirebaseStorageTests.swift
+++ b/Tests/SkipFirebaseStorageTests/SkipFirebaseStorageTests.swift
@@ -35,6 +35,8 @@ let logger: Logger = Logger(subsystem: "SkipFirebaseStorageTests", category: "Te
             let fileURL = URL(fileURLWithPath: "/dev/null")
 
             // we don't actually connect to the storage here, so we are just checking the API signatures for get/put data
+            let storageCustomURL = Storage.storage(url: "gs://")
+
             let storage = Storage.storage()
             let ref: StorageReference = storage.reference()
             let _: StorageReference = storage.reference(withPath: "test")


### PR DESCRIPTION
- Adds storage instance with custom URL support
- Fixes `putFile` passing nil metadata (which causes an error in the FireBase SDK)

Skip Pull Request Checklist:
- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
