### PR TITLE
Fix Firestore API signatures and await data updates

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -657,7 +657,7 @@ public enum DocumentChangeType {
     case removed
 }
 
-public class BaseDocumentSnapshot: KotlinConverting<com.google.firebase.firestore.DocumentSnapshot> {
+public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.DocumentSnapshot> {
     public let doc: com.google.firebase.firestore.DocumentSnapshot
 
     public init(doc: com.google.firebase.firestore.DocumentSnapshot) {
@@ -684,6 +684,14 @@ public class BaseDocumentSnapshot: KotlinConverting<com.google.firebase.firestor
         doc.exists()
     }
 
+    public func data() -> [String: Any]? {
+        if let data = doc.getData() {
+            return deepSwift(map: data)
+        } else {
+            return nil
+        }
+    }
+
     public func get(_ fieldName: String) -> Any? {
         guard let value = doc.get(fieldName) else {
             return nil
@@ -692,17 +700,7 @@ public class BaseDocumentSnapshot: KotlinConverting<com.google.firebase.firestor
     }
 }
 
-public class DocumentSnapshot: BaseDocumentSnapshot {
-    public func data() -> [String: Any]? {
-        if let data = doc.getData() {
-            return deepSwift(map: data)
-        } else {
-            return nil
-        }
-    }
-}
-
-public class QueryDocumentSnapshot: BaseDocumentSnapshot {
+public class QueryDocumentSnapshot : DocumentSnapshot {
     public var snapshot: com.google.firebase.firestore.QueryDocumentSnapshot {
         doc as! com.google.firebase.firestore.QueryDocumentSnapshot
     }
@@ -715,7 +713,7 @@ public class QueryDocumentSnapshot: BaseDocumentSnapshot {
         DocumentReference(ref: snapshot.reference)
     }
 
-    public func data() -> [String: Any] {
+    override public func data() -> [String: Any] {
         if let data = doc.getData() {
             return deepSwift(map: data)
         } else {

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -657,7 +657,7 @@ public enum DocumentChangeType {
     case removed
 }
 
-public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.DocumentSnapshot> {
+public class BaseDocumentSnapshot: KotlinConverting<com.google.firebase.firestore.DocumentSnapshot> {
     public let doc: com.google.firebase.firestore.DocumentSnapshot
 
     public init(doc: com.google.firebase.firestore.DocumentSnapshot) {
@@ -684,14 +684,6 @@ public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.Do
         doc.exists()
     }
 
-    public func data() -> [String: Any] {
-        if let data = doc.getData() {
-            return deepSwift(map: data)
-        } else {
-            return [:]
-        }
-    }
-
     public func get(_ fieldName: String) -> Any? {
         guard let value = doc.get(fieldName) else {
             return nil
@@ -700,7 +692,17 @@ public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.Do
     }
 }
 
-public class QueryDocumentSnapshot : DocumentSnapshot {
+public class DocumentSnapshot: BaseDocumentSnapshot {
+    public func data() -> [String: Any]? {
+        if let data = doc.getData() {
+            return deepSwift(map: data)
+        } else {
+            return nil
+        }
+    }
+}
+
+public class QueryDocumentSnapshot: BaseDocumentSnapshot {
     public var snapshot: com.google.firebase.firestore.QueryDocumentSnapshot {
         doc as! com.google.firebase.firestore.QueryDocumentSnapshot
     }
@@ -711,6 +713,14 @@ public class QueryDocumentSnapshot : DocumentSnapshot {
 
     public var reference: DocumentReference {
         DocumentReference(ref: snapshot.reference)
+    }
+
+    public func data() -> [String: Any] {
+        if let data = doc.getData() {
+            return deepSwift(map: data)
+        } else {
+            return [:]
+        }
     }
 }
 

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -778,14 +778,14 @@ public class DocumentReference: KotlinConverting<com.google.firebase.firestore.D
 
     public func setData(_ keyValues: [String: Any], merge: Bool = false) async throws {
         if merge == true {
-            ref.set(keyValues.kotlin(), com.google.firebase.firestore.SetOptions.merge())
+            ref.set(keyValues.kotlin(), com.google.firebase.firestore.SetOptions.merge()).await()
         } else {
-            ref.set(keyValues.kotlin())
+            ref.set(keyValues.kotlin()).await()
         }
     }
 
     public func updateData(_ keyValues: [String: Any]) async throws {
-        ref.update(keyValues.kotlin() as! Map<String, Any>)
+        ref.update(keyValues.kotlin() as! Map<String, Any>).await()
     }
 
     public func collection(_ collectionPath: String) -> CollectionReference {

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -357,6 +357,7 @@ var appName: String = "SkipFirebaseDemo"
         do {
             let snapshot = try await ref.getDocument()
             XCTAssertFalse(snapshot.exists)
+            XCTAssertNil(snapshot.data())
         }
     }
     

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -306,6 +306,10 @@ var appName: String = "SkipFirebaseDemo"
 
         let doc2 = try await doc2Ref.getDocument()
         XCTAssertEqual(when, doc2.get("when") as? Double)
+
+        try await assertExistsFalseForNonExistentDocument()
+
+        try await assertExistsTrueForExistentDocument()
     }
 
     // test disabled because we cannot seem to have multiple simultaneous firebase setups running
@@ -349,7 +353,7 @@ var appName: String = "SkipFirebaseDemo"
         await cacheApp.delete()
     }
 
-    func testExistsFalseForNonExistentDocument() async throws {
+    func assertExistsFalseForNonExistentDocument() async throws {
         XCTAssertEqual(appName, self.app.name)
         let citiesRef = db.collection("cities")
         let bos = citiesRef.document("BOS")
@@ -361,7 +365,6 @@ var appName: String = "SkipFirebaseDemo"
             XCTAssertNil(snapshot.data())
         }
         do {
-            let data = ["name": "NON_EXISTENT"]
             try await ref.updateData(Self.bostonData)
             XCTFail("updateData should throw on non-existent document")
         } catch {
@@ -369,7 +372,7 @@ var appName: String = "SkipFirebaseDemo"
         }
     }
 
-    func testExistsTrueForExistentDocument() async throws {
+    func assertExistsTrueForExistentDocument() async throws {
         XCTAssertEqual(appName, self.app.name)
         let citiesRef = db.collection("cities")
         let bos = citiesRef.document("BOS")

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -229,7 +229,8 @@ var appName: String = "SkipFirebaseDemo"
         XCTAssertEqual(Timestamp(date: Date(timeIntervalSince1970: 1234)), bdoc.get("time") as? Timestamp)
 
         XCTAssertEqual(555000, bdoc.get("population") as? Int64)
-        try await bos.updateData(["population": 675000])
+        let bosData: [String: Any] = ["population": 675000]
+        try await bos.updateData(bosData)
 
         XCTAssertEqual(555000, bdoc.get("population") as? Int64)
         let bdoc2 = try await bos.getDocument()
@@ -347,8 +348,8 @@ var appName: String = "SkipFirebaseDemo"
         // SKIP NOWARN
         await cacheApp.delete()
     }
-    
-    func DISABLEDtestExistsFalseForNonExistentDocument() async throws {
+
+    func testExistsFalseForNonExistentDocument() async throws {
         XCTAssertEqual(appName, self.app.name)
         let citiesRef = db.collection("cities")
         let bos = citiesRef.document("BOS")
@@ -359,9 +360,16 @@ var appName: String = "SkipFirebaseDemo"
             XCTAssertFalse(snapshot.exists)
             XCTAssertNil(snapshot.data())
         }
+        do {
+            let data = ["name": "NON_EXISTENT"]
+            try await ref.updateData(Self.bostonData)
+            XCTFail("updateData should throw on non-existent document")
+        } catch {
+            XCTAssert(true)
+        }
     }
-    
-    func DISABLEDtestExistsTrueForExistentDocument() async throws {
+
+    func testExistsTrueForExistentDocument() async throws {
         XCTAssertEqual(appName, self.app.name)
         let citiesRef = db.collection("cities")
         let bos = citiesRef.document("BOS")


### PR DESCRIPTION
DocumentSnapshot's data method should be optional because it can reference a non-existent document, whereas QueryDocumentSnapshot only returns valid documents that match the query, so its data is non-optional. This change matches the iOS API.

Promises in setData and updateData weren't handled, which meant they returned immediately and errors couldn't be caught.

~I reenabled `testExistsFalseForNonExistentDocument` and `testExistsTrueForExistentDocument`. They aren't doing anything beyond `testFirestore` so I thought this should be okay, but of course I can revert that if they are causing CI issues (from https://github.com/skiptools/skip-firebase/commit/e44d302b8ffaeb9ca6f232db7e212d83bbc6f88e).~
Edit: I see that separate tests cause `setUp` to fail on CI (commented out `tearDown` doesn't work?). So I made `testFirestore` call these instead.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
