### PR TITLE
Add support for calling HTTP callable functions

### DIFF
--- a/Sources/SkipFirebaseFunctions/SkipFirebaseFunctions.swift
+++ b/Sources/SkipFirebaseFunctions/SkipFirebaseFunctions.swift
@@ -3,6 +3,7 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if SKIP
+import SkipFoundation
 import SkipFirebaseCore
 import kotlinx.coroutines.tasks.await
 
@@ -23,5 +24,74 @@ public final class Functions {
     public static func functions(app: FirebaseApp) -> Functions {
         Functions(functions: com.google.firebase.functions.FirebaseFunctions.getInstance(app.app))
     }
+
+    public func useEmulator(withHost host: String, port: Int) {
+        functions.useEmulator(host, port)
+    }
+
+    public func httpsCallable(_ name: String) -> HTTPSCallable {
+        HTTPSCallable(functions.getHttpsCallable(name))
+    }
 }
+
+public class HTTPSCallable: KotlinConverting<com.google.firebase.functions.HttpsCallableReference> {
+    public let platformValue: com.google.firebase.functions.HttpsCallableReference
+
+    public init(_ platformValue: com.google.firebase.functions.HttpsCallableReference) {
+        self.platformValue = platformValue
+    }
+
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.functions.HttpsCallableReference {
+        platformValue
+    }
+
+    public var description: String {
+        platformValue.toString()
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.platformValue == rhs.platformValue
+    }
+
+    public func call(_ data: Any? = nil,
+               completion: @escaping (HTTPSCallableResult?,
+                                      Error?) -> Void) {
+        (data == nil ? platformValue.call() : platformValue.call(data!.kotlin()))
+        .addOnSuccessListener { httpsCallableResult in
+            completion(HTTPSCallableResult(httpsCallableResult), nil)
+        }
+        .addOnFailureListener { exception in
+            completion(nil, ErrorException(exception))
+        }
+    }
+}
+
+public class HTTPSCallableResult: KotlinConverting<com.google.firebase.functions.HttpsCallableResult> {
+    public let platformValue: com.google.firebase.functions.HttpsCallableResult
+
+    public init(_ platformValue: com.google.firebase.functions.HttpsCallableResult) {
+        self.platformValue = platformValue
+    }
+
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.functions.HttpsCallableResult {
+        platformValue
+    }
+
+    public var description: String {
+        platformValue.toString()
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.platformValue == rhs.platformValue
+    }
+
+    public var data: Any {
+        if let data = platformValue.getData() {
+            return data
+        } else {
+            assertionFailure("com.google.firebase.functions.HttpsCallableResult returned nil and the Swift API returns a non-nil Any")
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
This PR adds support for calling HTTP callable functions.

Firebase documentation: [Call functions from your app](https://firebase.google.com/docs/functions/callable?gen=2nd#swift)

Usage example:

```
#if !SKIP
import FirebaseFunctions
#else
import SkipFirebaseFunctions
#endif

let functions: Functions = Functions.functions()

functions.httpsCallable("functionName").call(["some": "data"]) { result, error in
    logger.log("functionName result: \(String(describing: result?.data)), error: \(String(describing: error))")
}
```
Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

