### PR TITLE
Add Firestore Filter factory methods

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -391,9 +391,10 @@ public class Query: KotlinConverting<com.google.firebase.firestore.Query> {
         Query(query: query.whereIn(field, array.kotlin()))
     }
 
-//    public func whereField(_ field: String, notIn: [Any]) -> Query {
-//        Query(query: query.whereNotIn(field, notIn.kotlin()))
-//    }
+    // SKIP DECLARE: fun whereField(field: String, notIn: Array<Any>, @Suppress("UNUSED_PARAMETER") unusedp_0: Nothing? = null): Query
+    public func whereField(_ field: String, notIn: [Any]) -> Query {
+        Query(query: query.whereNotIn(field, notIn.kotlin()))
+    }
 
     public func whereField(_ field: String, isEqualTo: Any) -> Query {
         Query(query: query.whereEqualTo(field, isEqualTo.kotlin()))
@@ -423,18 +424,19 @@ public class Query: KotlinConverting<com.google.firebase.firestore.Query> {
         Query(query: query.whereArrayContains(field, arrayContains.kotlin()))
     }
 
-    public func whereField(_ field: String, arrayContainsAny: [Any]) -> Query {
-        Query(query: query.whereArrayContainsAny(field, arrayContainsAny.kotlin()))
-    }
-
-
     public func whereField(_ field: FieldPath, in array: [Any]) -> Query {
         Query(query: query.whereIn(field.fieldPath, array.kotlin()))
     }
 
-//    public func whereField(_ field: FieldPath, notIn: [Any]) -> Query {
-//        Query(query: query.whereNotIn(field.fieldPath, notIn.kotlin()))
-//    }
+    // SKIP DECLARE: fun whereField(field: String, arrayContainsAny: Array<Any>, @Suppress("UNUSED_PARAMETER") unusedp_0: Nothing? = null, @Suppress("UNUSED_PARAMETER") unusedp_1: Nothing? = null): Query
+    public func whereField(_ field: String, arrayContainsAny: [Any]) -> Query {
+        Query(query: query.whereArrayContainsAny(field, arrayContainsAny.kotlin()))
+    }
+
+    // SKIP DECLARE: fun whereField(field: FieldPath, notIn: Array<Any>, @Suppress("UNUSED_PARAMETER") unusedp_0: Nothing? = null, @Suppress("UNUSED_PARAMETER") unusedp_1: Nothing? = null, @Suppress("UNUSED_PARAMETER") unusedp_2: Nothing? = null): Query
+    public func whereField(_ field: FieldPath, notIn: [Any]) -> Query {
+        Query(query: query.whereNotIn(field.fieldPath, notIn.kotlin()))
+    }
 
     public func whereField(_ field: FieldPath, isEqualTo: Any) -> Query {
         Query(query: query.whereEqualTo(field.fieldPath, isEqualTo.kotlin()))

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -213,6 +213,107 @@ public class Filter: KotlinConverting<com.google.firebase.firestore.Filter> {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.filter == rhs.filter
     }
+
+    // Kotlin does not support overloading functions only by parameter name. Use the Kotlin Firestore API signature from https://firebase.google.com/docs/reference/kotlin/com/google/firebase/firestore/Filter in `#if SKIP` blocks.
+    public static func whereField(_ field: String, isEqualTo value: Any) -> Filter {
+        equalTo(field, value)
+    }
+
+    public static func equalTo(field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.equalTo(field, value.kotlin()))
+    }
+
+    public static func notEqualTo(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.notEqualTo(field, value.kotlin()))
+    }
+
+    public static func greaterThan(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.greaterThan(field, value.kotlin()))
+    }
+
+    public static func greaterThanOrEqualTo(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.greaterThanOrEqualTo(field, value.kotlin()))
+    }
+
+    public static func lessThan(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.lessThan(field, value.kotlin()))
+    }
+
+    public static func lessThanOrEqualTo(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.lessThanOrEqualTo(field, value.kotlin()))
+    }
+
+    public static func arrayContains(_ field: String, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.arrayContains(field, value.kotlin()))
+    }
+
+    public static func arrayContainsAny(_ field: String, _ values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.arrayContainsAny(field, values.kotlin()))
+    }
+
+    public static func inArray(_ field: String, values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.inArray(field, values.kotlin()))
+    }
+
+    public static func notInArray(_ field: String, values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.notInArray(field, values.kotlin()))
+    }
+
+    // Kotlin does not support overloading functions only by parameter name. Use the Kotlin Firestore API signature from https://firebase.google.com/docs/reference/kotlin/com/google/firebase/firestore/Filter in `#if SKIP` blocks.
+    public static func whereField(_ fieldPath: FieldPath, isEqualTo value: Any) -> Filter {
+        equalTo(fieldPath, value)
+    }
+
+    public static func equalTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.equalTo(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func notEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.notEqualTo(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func greaterThan(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.greaterThan(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func greaterThanOrEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.greaterThanOrEqualTo(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func lessThan(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.lessThan(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func lessThanOrEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.lessThanOrEqualTo(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func arrayContains(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.arrayContains(fieldPath.fieldPath, value.kotlin()))
+    }
+
+    public static func arrayContainsAny(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.arrayContainsAny(fieldPath.fieldPath, values.kotlin()))
+    }
+
+    public static func inArray(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.inArray(fieldPath.fieldPath, values.kotlin()))
+    }
+
+    public static func notInArray(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+        Filter(filter: com.google.firebase.firestore.Filter.notInArray(fieldPath.fieldPath, values.kotlin()))
+    }
+
+
+    public static func orFilter(_ filters: [Filter]) -> Filter {
+        let platformFilters = filters.map(\.filter).toList().toTypedArray()
+        return Filter(filter: com.google.firebase.firestore.Filter.or(*platformFilters))
+    }
+
+    public static func andFilter(_ filters: [Filter]) -> Filter {
+        let platformFilters = filters.map(\.filter).toList().toTypedArray()
+        return Filter(filter: com.google.firebase.firestore.Filter.and(*platformFilters))
+    }
 }
 
 public class SnapshotMetadata: KotlinConverting<com.google.firebase.firestore.SnapshotMetadata> {

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -214,96 +214,85 @@ public class Filter: KotlinConverting<com.google.firebase.firestore.Filter> {
         lhs.filter == rhs.filter
     }
 
-    // Kotlin does not support overloading functions only by parameter name. Use the Kotlin Firestore API signature from https://firebase.google.com/docs/reference/kotlin/com/google/firebase/firestore/Filter in `#if SKIP` blocks.
     public static func whereField(_ field: String, isEqualTo value: Any) -> Filter {
-        equalTo(field, value)
-    }
-
-    public static func equalTo(field: String, _ value: Any) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.equalTo(field, value.kotlin()))
     }
 
-    public static func notEqualTo(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, isNotEqualTo value: Any, unusedp_0: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.notEqualTo(field, value.kotlin()))
     }
 
-    public static func greaterThan(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, isGreaterThan value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.greaterThan(field, value.kotlin()))
     }
 
-    public static func greaterThanOrEqualTo(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, isGreaterThanOrEqualTo value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.greaterThanOrEqualTo(field, value.kotlin()))
     }
 
-    public static func lessThan(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, isLessThan value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.lessThan(field, value.kotlin()))
     }
 
-    public static func lessThanOrEqualTo(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, isLessThanOrEqualTo value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil, unusedp_4: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.lessThanOrEqualTo(field, value.kotlin()))
     }
 
-    public static func arrayContains(_ field: String, _ value: Any) -> Filter {
+    public static func whereField(_ field: String, arrayContains value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil, unusedp_4: Nothing? = nil, unusedp_5: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.arrayContains(field, value.kotlin()))
     }
 
-    public static func arrayContainsAny(_ field: String, _ values: [Any]) -> Filter {
+    public static func whereField(_ field: String, arrayContainsAny values: [Any]) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.arrayContainsAny(field, values.kotlin()))
     }
 
-    public static func inArray(_ field: String, values: [Any]) -> Filter {
+    public static func whereField(_ field: String, in values: [Any], unusedp_0: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.inArray(field, values.kotlin()))
     }
 
-    public static func notInArray(_ field: String, values: [Any]) -> Filter {
+    public static func whereField(_ field: String, notIn values: [Any], unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.notInArray(field, values.kotlin()))
     }
 
-    // Kotlin does not support overloading functions only by parameter name. Use the Kotlin Firestore API signature from https://firebase.google.com/docs/reference/kotlin/com/google/firebase/firestore/Filter in `#if SKIP` blocks.
     public static func whereField(_ fieldPath: FieldPath, isEqualTo value: Any) -> Filter {
-        equalTo(fieldPath, value)
-    }
-
-    public static func equalTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.equalTo(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func notEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, isNotEqualTo value: Any, unusedp_0: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.notEqualTo(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func greaterThan(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, isGreaterThan value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.greaterThan(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func greaterThanOrEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, isGreaterThanOrEqualTo value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.greaterThanOrEqualTo(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func lessThan(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, isLessThan value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.lessThan(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func lessThanOrEqualTo(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, isLessThanOrEqualTo value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil, unusedp_4: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.lessThanOrEqualTo(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func arrayContains(_ fieldPath: FieldPath, _ value: Any) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, arrayContains value: Any, unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil, unusedp_2: Nothing? = nil, unusedp_3: Nothing? = nil, unusedp_4: Nothing? = nil, unusedp_5: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.arrayContains(fieldPath.fieldPath, value.kotlin()))
     }
 
-    public static func arrayContainsAny(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, arrayContainsAny values: [Any]) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.arrayContainsAny(fieldPath.fieldPath, values.kotlin()))
     }
 
-    public static func inArray(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, in values: [Any], unusedp_0: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.inArray(fieldPath.fieldPath, values.kotlin()))
     }
 
-    public static func notInArray(_ fieldPath: FieldPath, _ values: [Any]) -> Filter {
+    public static func whereField(_ fieldPath: FieldPath, notIn values: [Any], unusedp_0: Nothing? = nil, unusedp_1: Nothing? = nil) -> Filter {
         Filter(filter: com.google.firebase.firestore.Filter.notInArray(fieldPath.fieldPath, values.kotlin()))
     }
-
 
     public static func orFilter(_ filters: [Filter]) -> Filter {
         let platformFilters = filters.map(\.filter).toList().toTypedArray()

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -127,13 +127,10 @@ var appName: String = "SkipFirebaseDemo"
         let _: Query = colRef.order(by: "x", descending: true)
 
         let _: Query = colRef.whereFilter(Filter())
-        var orFilters = [Filter.whereField("foo", isEqualTo: "bar")]
-#if !SKIP
-        orFilters.append(Filter.whereField("foo", isNotEqualTo: "bar"))
-#else
-        orFilters.append(Filter.notEqualTo("foo", "bar"))
-#endif
-        let _: Query = colRef.whereFilter(Filter.orFilter(orFilters))
+        let _: Query = colRef.whereFilter(Filter.orFilter([
+            Filter.whereField("foo", isEqualTo: "bar"),
+            Filter.whereField("foo", isNotEqualTo: "bar")
+        ]))
 
         let _: Query = colRef.whereField("x", in: ["x"])
         //let _: Query = colRef.whereField("x", notIn: ["x"])

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -127,6 +127,13 @@ var appName: String = "SkipFirebaseDemo"
         let _: Query = colRef.order(by: "x", descending: true)
 
         let _: Query = colRef.whereFilter(Filter())
+        var orFilters = [Filter.whereField("foo", isEqualTo: "bar")]
+#if !SKIP
+        orFilters.append(Filter.whereField("foo", isNotEqualTo: "bar"))
+#else
+        orFilters.append(Filter.notEqualTo("foo", "bar"))
+#endif
+        let _: Query = colRef.whereFilter(Filter.orFilter(orFilters))
 
         let _: Query = colRef.whereField("x", in: ["x"])
         //let _: Query = colRef.whereField("x", notIn: ["x"])


### PR DESCRIPTION
This is up for discussion as I made some opinionated decisions as this Swift API is not 1:1 translatable in Kotlin:
- I used the API signature from the Kotlin Firebase library instead for these methods (this requires end users to use `#if SKIP #else` blocks)
- In addition, I added `whereField(_ field: String, isEqualTo: Any)` from the Swift API, since I believe this is the most commonly used `whereField` variant (but this could create confusion as to why changing `isEqualTo` to `isNotEqualTo` no longer compiles)

See the test case I added for what this looks like in practice.

I also updated Query using the same trick the transpiler does under the hood of generating unused parameters with default values to differentiate function signatures (without impacting call signature). For whatever reason the transpiler doesn't generate this automatically with an array parameter present. Because our Swift code enforces parameter labels, it seems safe to use. I tested these methods explicitly on an Android device.

We apparently can't exploit this for Filter because these methods are static. The transpiler turns them into overriding methods under the hood, and the compiler complains that "an overriding function is not allowed to specify default values for its parameters". Maybe it's possible to manually rewrite the Filter class in Kotlin to avoid using override? Open to suggestions or better ways to do this!

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device