### PR TITLE
Add Firestore error codes

### DIFF
--- a/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
+++ b/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
@@ -12,175 +12,175 @@ import android.net.Uri
 // https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth
 
 public final class Auth {
-	public let platformValue: com.google.firebase.auth.FirebaseAuth
+    public let platformValue: com.google.firebase.auth.FirebaseAuth
 
-	public init(platformValue: com.google.firebase.auth.FirebaseAuth) {
-		self.platformValue = platformValue
-	}
+    public init(platformValue: com.google.firebase.auth.FirebaseAuth) {
+        self.platformValue = platformValue
+    }
 
-	public static func auth() -> Auth {
-		Auth(platformValue: com.google.firebase.auth.FirebaseAuth.getInstance())
-	}
+    public static func auth() -> Auth {
+        Auth(platformValue: com.google.firebase.auth.FirebaseAuth.getInstance())
+    }
 
-	public static func auth(app: FirebaseApp) -> Auth {
-		Auth(platformValue: com.google.firebase.auth.FirebaseAuth.getInstance(app.app))
-	}
-	
-	public var app: FirebaseApp {
-		FirebaseApp(app: platformValue.getApp())
-	}
+    public static func auth(app: FirebaseApp) -> Auth {
+        Auth(platformValue: com.google.firebase.auth.FirebaseAuth.getInstance(app.app))
+    }
 
-	public var currentUser: User? {
-		guard let user = platformValue.currentUser else { return nil }
-		return User(user)
-	}
-	
-	public func signIn(withEmail email: String, password: String) async throws -> AuthDataResult {
-		let result = platformValue.signInWithEmailAndPassword(email, password).await()
-		return AuthDataResult(result)
-	}
-	
-	public func createUser(withEmail email: String, password: String) async throws -> AuthDataResult {
-		let result = platformValue.createUserWithEmailAndPassword(email, password).await()
-		return AuthDataResult(result)
-	}
+    public var app: FirebaseApp {
+        FirebaseApp(app: platformValue.getApp())
+    }
 
-	public func signOut() throws {
-		platformValue.signOut()
-	}
+    public var currentUser: User? {
+        guard let user = platformValue.currentUser else { return nil }
+        return User(user)
+    }
 
-	public func sendPasswordReset(withEmail email: String) async throws {
-		platformValue.sendPasswordResetEmail(email).await()
-	}
+    public func signIn(withEmail email: String, password: String) async throws -> AuthDataResult {
+        let result = platformValue.signInWithEmailAndPassword(email, password).await()
+        return AuthDataResult(result)
+    }
 
-	public func signInAnonymously() async throws -> AuthDataResult {
-		let result = platformValue.signInAnonymously().await()
-		return AuthDataResult(result)
-	}
+    public func createUser(withEmail email: String, password: String) async throws -> AuthDataResult {
+        let result = platformValue.createUserWithEmailAndPassword(email, password).await()
+        return AuthDataResult(result)
+    }
 
- 	public func useEmulator(withHost host: String, port: Int) {
-		platformValue.useEmulator(host, port)
- 	}
+    public func signOut() throws {
+        platformValue.signOut()
+    }
 
-	public func addStateDidChangeListener(_ listener: @escaping (Auth, User?) -> Void) -> AuthStateListener {
-		let stateListener = com.google.firebase.auth.FirebaseAuth.AuthStateListener { auth in
-			let user = auth.currentUser != nil ? User(auth.currentUser!) : nil
-			listener(Auth(platformValue: auth), user)
-		}
-		platformValue.addAuthStateListener(stateListener)
-		return AuthStateListener(platformValue: stateListener)
-	}
+    public func sendPasswordReset(withEmail email: String) async throws {
+        platformValue.sendPasswordResetEmail(email).await()
+    }
 
-	public func removeStateDidChangeListener(_ listenerHandle: NSObjectProtocol) {
-		platformValue.removeAuthStateListener((listenerHandle as AuthStateListener).platformValue)
-	}
+    public func signInAnonymously() async throws -> AuthDataResult {
+        let result = platformValue.signInAnonymously().await()
+        return AuthDataResult(result)
+    }
+
+     public func useEmulator(withHost host: String, port: Int) {
+        platformValue.useEmulator(host, port)
+     }
+
+    public func addStateDidChangeListener(_ listener: @escaping (Auth, User?) -> Void) -> AuthStateListener {
+        let stateListener = com.google.firebase.auth.FirebaseAuth.AuthStateListener { auth in
+            let user = auth.currentUser != nil ? User(auth.currentUser!) : nil
+            listener(Auth(platformValue: auth), user)
+        }
+        platformValue.addAuthStateListener(stateListener)
+        return AuthStateListener(platformValue: stateListener)
+    }
+
+    public func removeStateDidChangeListener(_ listenerHandle: NSObjectProtocol) {
+        platformValue.removeAuthStateListener((listenerHandle as AuthStateListener).platformValue)
+    }
 }
 
 public class AuthDataResult: KotlinConverting<com.google.firebase.auth.AuthResult> {
-	public let platformValue: com.google.firebase.auth.AuthResult
+    public let platformValue: com.google.firebase.auth.AuthResult
 
-	public init(_ platformValue: com.google.firebase.auth.AuthResult) {
-		self.platformValue = platformValue
-	}
-	
-	public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.AuthResult {
-		platformValue
-	}
-	
-	public var description: String {
-		platformValue.toString()
-	}
-	
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.platformValue == rhs.platformValue
-	}
-	
-	public var user: User {
-		User(platformValue.user!)
-	}
+    public init(_ platformValue: com.google.firebase.auth.AuthResult) {
+        self.platformValue = platformValue
+    }
+
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.AuthResult {
+        platformValue
+    }
+
+    public var description: String {
+        platformValue.toString()
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.platformValue == rhs.platformValue
+    }
+
+    public var user: User {
+        User(platformValue.user!)
+    }
 }
 
 public class AuthStateListener: NSObjectProtocol {
-	public let platformValue: com.google.firebase.auth.FirebaseAuth.AuthStateListener
+    public let platformValue: com.google.firebase.auth.FirebaseAuth.AuthStateListener
 
-	public init(platformValue: com.google.firebase.auth.FirebaseAuth.AuthStateListener) {
-		self.platformValue = platformValue
-	}
+    public init(platformValue: com.google.firebase.auth.FirebaseAuth.AuthStateListener) {
+        self.platformValue = platformValue
+    }
 }
 
 public class User: KotlinConverting<com.google.firebase.auth.FirebaseUser> {
-	public let platformValue: com.google.firebase.auth.FirebaseUser
-	
-	public init(_ platformValue: com.google.firebase.auth.FirebaseUser) {
-		self.platformValue = platformValue
-	}
-	
-	public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.FirebaseUser {
-		platformValue
-	}
-	
-	public var description: String {
-		platformValue.toString()
-	}
-	
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.platformValue == rhs.platformValue
-	}
-	
-	public var isAnonymous: Bool {
-		platformValue.isAnonymous
-	}
+    public let platformValue: com.google.firebase.auth.FirebaseUser
 
-	public var providerID: String? {
-		platformValue.providerId
-	}
+    public init(_ platformValue: com.google.firebase.auth.FirebaseUser) {
+        self.platformValue = platformValue
+    }
 
-	public var uid: String {
-		platformValue.uid
-	}
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.FirebaseUser {
+        platformValue
+    }
 
-	public var displayName: String? {
-		platformValue.displayName
-	}
+    public var description: String {
+        platformValue.toString()
+    }
 
-	public var photoURL: URL? {
-		guard let uri = platformValue.photoUrl else { return nil }
-		return URL(string: uri.toString())!
-	}
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.platformValue == rhs.platformValue
+    }
 
-	public var email: String? {
-		platformValue.email
-	}
+    public var isAnonymous: Bool {
+        platformValue.isAnonymous
+    }
 
-	public var phoneNumber: String? {
-		platformValue.phoneNumber
-	}
-	
-	public func createProfileChangeRequest() -> UserProfileChangeRequest {
-		return UserProfileChangeRequest(self)
-	}
+    public var providerID: String? {
+        platformValue.providerId
+    }
+
+    public var uid: String {
+        platformValue.uid
+    }
+
+    public var displayName: String? {
+        platformValue.displayName
+    }
+
+    public var photoURL: URL? {
+        guard let uri = platformValue.photoUrl else { return nil }
+        return URL(string: uri.toString())!
+    }
+
+    public var email: String? {
+        platformValue.email
+    }
+
+    public var phoneNumber: String? {
+        platformValue.phoneNumber
+    }
+
+    public func createProfileChangeRequest() -> UserProfileChangeRequest {
+        return UserProfileChangeRequest(self)
+    }
 }
 
 public class UserProfileChangeRequest/*: KotlinConverting<com.google.firebase.auth.UserProfileChangeRequest>*/ {
-	var user: User
-	
-	fileprivate init(user: User) {
-		self.user = user
-	}
-	
-	public var displayName: String?
-	
-	public func commitChanges() async throws {
-		let builder = com.google.firebase.auth.UserProfileChangeRequest.Builder()
-		
-		if let displayName {
-			builder.setDisplayName(displayName)
-		}
-		
-		let platformChangeRequest: com.google.firebase.auth.UserProfileChangeRequest = builder.build()
-		
-		user.platformValue.updateProfile(platformChangeRequest).await()
-	}
+    var user: User
+
+    fileprivate init(user: User) {
+        self.user = user
+    }
+
+    public var displayName: String?
+
+    public func commitChanges() async throws {
+        let builder = com.google.firebase.auth.UserProfileChangeRequest.Builder()
+
+        if let displayName {
+            builder.setDisplayName(displayName)
+        }
+
+        let platformChangeRequest: com.google.firebase.auth.UserProfileChangeRequest = builder.build()
+
+        user.platformValue.updateProfile(platformChangeRequest).await()
+    }
 }
 
 #endif

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -81,6 +81,10 @@ public final class Firestore: KotlinConverting<com.google.firebase.firestore.Fir
     public func useEmulator(withHost host: String, port: Int) {
         store.useEmulator(host, port)
     }
+
+    public func document(_ path: String) -> DocumentReference {
+        DocumentReference(ref: store.document(path))
+    }
 }
 
 /// A FieldPath refers to a field in a document. The path may consist of a single field name (referring to a top level field in the document), or a list of field names (referring to a nested field in the document).

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -71,7 +71,7 @@ public final class Firestore: KotlinConverting<com.google.firebase.firestore.Fir
     }
 
     public func collectionGroup(collectionId: String) -> Query {
-        return Query(query: store.collectionGroup(collectionId)) 
+        return Query(query: store.collectionGroup(collectionId))
     }
 
     public func batch() -> WriteBatch {
@@ -96,7 +96,7 @@ public class FieldPath : Hashable, KotlinConverting<com.google.firebase.firestor
     }
 
     public init(_ fieldNames: [String]) {
-        let fnames: kotlin.Array<String> = fieldNames.toList().toTypedArray()
+        let fnames = fieldNames.toList().toTypedArray()
         self.fieldPath = com.google.firebase.firestore.FieldPath.of(*fnames)
     }
 
@@ -775,7 +775,7 @@ public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.Do
     public var documentID: String {
         doc.getId()
     }
-    
+
     public var exists: Bool {
         doc.exists()
     }
@@ -971,7 +971,7 @@ public class WriteBatch {
         let newBatch = batch.set(document.ref, data.kotlin())
         return WriteBatch(batch: newBatch)
     }
-    
+
     public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [String]) -> WriteBatch {
         let newBatch = batch.set(document.ref, data.kotlin(), com.google.firebase.firestore.SetOptions.mergeFields(mergeFields.toList()))
         return WriteBatch(batch: newBatch)
@@ -985,12 +985,12 @@ public class WriteBatch {
 
 public class FieldValue {
     public class func arrayRemove(_ elements: [Any]) -> com.google.firebase.firestore.FieldValue {
-        let elementsArray: kotlin.Array<Any> = elements.toList().toTypedArray()
+        let elementsArray = elements.toList().toTypedArray()
         return com.google.firebase.firestore.FieldValue.arrayRemove(*elementsArray)
     }
 
     public class func arrayUnion(_ elements: [Any]) -> com.google.firebase.firestore.FieldValue {
-        let elementsArray: kotlin.Array<Any> = elements.toList().toTypedArray()
+        let elementsArray = elements.toList().toTypedArray()
         return com.google.firebase.firestore.FieldValue.arrayUnion(*elementsArray)
     }
 

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -1007,6 +1007,28 @@ public class FieldValue {
     }
 }
 
+// MARK: Errors
+
+public enum FirestoreErrorCode: Int {
+    case OK = 0
+    case cancelled = 1
+    case unknown = 2
+    case invalidArgument = 3
+    case deadlineExceeded = 4
+    case notFound = 5
+    case alreadyExists = 6
+    case permissionDenied = 7
+    case resourceExhausted = 8
+    case failedPrecondition = 9
+    case aborted = 10
+    case outOfRange = 11
+    case unimplemented = 12
+    case `internal` = 13
+    case unavailable = 14
+    case dataLoss = 15
+    case unauthenticated = 16
+}
+
 // MARK: Utilies for converting between Swift and Kotlin types
 
 fileprivate func deepSwift(value: Any) -> Any {

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -96,6 +96,9 @@ var appName: String = "SkipFirebaseDemo"
     private func validateFirebaseWrapperAPI() async throws {
         //let db: Firestore = Firestore.firestore(app: self.app)
 
+        let cityDocumentFromRoot = db.document("cities/nyc")
+        XCTAssertEqual(cityDocumentFromRoot.documentID, "nyc")
+
         let colRef: CollectionReference = db.collection("")
         let _: Firestore = colRef.firestore
         let _: String = colRef.collectionID

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -230,6 +230,7 @@ var appName: String = "SkipFirebaseDemo"
 
         XCTAssertNotNil(bdoc.get("regions"))
 
+        // SKIP NOWARN
         XCTAssertEqual(["east_coast", "new_england"], bdoc.get("regions") as? [String])
 
         XCTAssertNotNil(bdoc.get("time"))

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -372,7 +372,15 @@ var appName: String = "SkipFirebaseDemo"
             try await ref.updateData(Self.bostonData)
             XCTFail("updateData should throw on non-existent document")
         } catch {
-            XCTAssert(true)
+            #if !SKIP
+            let error = error as NSError
+            XCTAssertEqual(error.domain, FirestoreErrorDomain)
+            let errorCode = error.code
+            #else
+            let exception = (error as Exception).cause as? com.google.firebase.firestore.FirebaseFirestoreException
+            let errorCode = exception?.code.value()
+            #endif
+            XCTAssertEqual(errorCode, FirestoreErrorCode.notFound.rawValue)
         }
     }
 


### PR DESCRIPTION
- Enable handling Firestore errors by adding `FirestoreErrorCode` enum
- Add missing `document(_ path:)` method to Firestore object
- Cleaned up some code formatting (hopefully that's okay to include here)

Currently it seems necessary for the user to ifdef to handle the platform error types separately in order to get the error code (see test case). I was thinking to add a note on this to the readme if that's the case. Any thoughts on a cleaner way to do this?

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device