### PR TITLE
Fix serialization of arrayRemove/arrayUnion elements

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -1026,12 +1026,12 @@ public class WriteBatch {
 
 public class FieldValue {
     public class func arrayRemove(_ elements: [Any]) -> com.google.firebase.firestore.FieldValue {
-        let elementsArray = elements.toList().toTypedArray()
+        let elementsArray = elements.map({ $0.kotlin() }).toList().toTypedArray()
         return com.google.firebase.firestore.FieldValue.arrayRemove(*elementsArray)
     }
 
     public class func arrayUnion(_ elements: [Any]) -> com.google.firebase.firestore.FieldValue {
-        let elementsArray = elements.toList().toTypedArray()
+        let elementsArray = elements.map({ $0.kotlin() }).toList().toTypedArray()
         return com.google.firebase.firestore.FieldValue.arrayUnion(*elementsArray)
     }
 

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -237,12 +237,16 @@ var appName: String = "SkipFirebaseDemo"
         XCTAssertEqual(Timestamp(date: Date(timeIntervalSince1970: 1234)), bdoc.get("time") as? Timestamp)
 
         XCTAssertEqual(555000, bdoc.get("population") as? Int64)
-        let bosData: [String: Any] = ["population": 675000]
+        let bosData: [String: Any] = ["population": 675000, "regions": FieldValue.arrayUnion(["new_england", "north_east"]), "newarray": FieldValue.arrayUnion([["foo": "bar"]])]
         try await bos.updateData(bosData)
 
         XCTAssertEqual(555000, bdoc.get("population") as? Int64)
         let bdoc2 = try await bos.getDocument()
         XCTAssertEqual(675000, bdoc2.get("population") as? Int64)
+        // SKIP NOWARN
+        XCTAssertEqual(3, (bdoc2.get("regions") as? [String] ?? []).count)
+        // SKIP NOWARN
+        XCTAssertEqual("bar", (bdoc2.get("newarray") as? [[String: String]] ?? []).first?["foo"])
 
         try await citiesRef.document("LA").setData([
             "name": "Los Angeles",


### PR DESCRIPTION
Currently, passing primitives to arrayRemove/arrayUnion works as expected. However if the elements are Skip collections, the Firebase SDK cannot serialize them, and update operations on these FieldValues will fail. Converting them to their Kotlin value fixes this.

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device