### PR TITLE
Add reauthenticate method to User class for Firebase Authentication

### DIFF
--- a/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
+++ b/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
@@ -174,6 +174,12 @@ public class User: KotlinConverting<com.google.firebase.auth.FirebaseUser> {
     }
 
     /// Throws `FirebaseAuthInvalidUserException`/`FirebaseAuthRecentLoginRequiredException`
+    /// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#reauthenticate(com.google.firebase.auth.AuthCredential)
+    public func reauthenticate(with credential: AuthCredential) async throws {
+        platformValue.reauthenticate(credential.platformValue).await()
+    }
+
+    /// Throws `FirebaseAuthInvalidUserException`/`FirebaseAuthRecentLoginRequiredException`
     /// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#delete()
     public func delete() async throws {
         platformValue.delete().await()
@@ -220,6 +226,25 @@ public class UserProfileChangeRequest/*: KotlinConverting<com.google.firebase.au
         let platformChangeRequest: com.google.firebase.auth.UserProfileChangeRequest = builder.build()
 
         user.platformValue.updateProfile(platformChangeRequest).await()
+    }
+}
+
+public class AuthCredential: KotlinConverting<com.google.firebase.auth.AuthCredential> {
+    public let platformValue: com.google.firebase.auth.AuthCredential
+    
+    public init(_ platformValue: com.google.firebase.auth.AuthCredential) {
+        self.platformValue = platformValue
+    }
+    
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.AuthCredential {
+        platformValue
+    }
+}
+
+public class EmailAuthProvider {
+    public static func credential(withEmail email: String, password: String) -> AuthCredential {
+        let credential = com.google.firebase.auth.EmailAuthProvider.getCredential(email, password)
+        return AuthCredential(credential)
     }
 }
 


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.
***
Added a reauthenticate with credentials function to Skip Firebase. This allows the user to check their password first before confirming an account deletion (for example). 

We use this in our app so that the user doesn't accidentally delete their account and training data, or someone else using their device doesn't do this to them.
***
Skip Pull Request Checklist:

- [ X ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [ X ] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [ X ] OPTIONAL: I have tested my change on an Android emulator or device

