### PR TITLE
Remove unneeded SkipUI dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,6 @@ let package = Package(
         .package(url: "https://source.skip.tools/skip.git", from: "1.3.2"),
         .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.3.1"),
         .package(url: "https://source.skip.tools/skip-model.git", from: "1.4.2"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.26.4"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "12.1.0")
     ],
     targets: [
@@ -54,7 +53,6 @@ let package = Package(
 
         .target(name: "SkipFirebaseAuth", dependencies: [
             "SkipFirebaseCore",
-            .product(name: "SkipUI", package: "skip-ui"),
             .product(name: "FirebaseAuth", package: "firebase-ios-sdk", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])),
         ], resources: [.process("Resources")], plugins: skipstone),
         .testTarget(name: "SkipFirebaseAuthTests", dependencies: [
@@ -73,7 +71,6 @@ let package = Package(
 
         .target(name: "SkipFirebaseMessaging", dependencies: [
             "SkipFirebaseCore",
-            .product(name: "SkipUI", package: "skip-ui"),
             .product(name: "FirebaseMessaging", package: "firebase-ios-sdk", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])),
         ], resources: [.process("Resources")], plugins: skipstone),
         .testTarget(name: "SkipFirebaseMessagingTests", dependencies: [

--- a/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
+++ b/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
@@ -6,7 +6,6 @@ import SkipFirebaseCore
 import android.app.Activity
 import kotlinx.coroutines.tasks.await
 import android.net.Uri
-import skip.ui.__
 
 // https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/Auth
 // https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth

--- a/Sources/SkipFirebaseMessaging/SkipFirebaseMessaging.swift
+++ b/Sources/SkipFirebaseMessaging/SkipFirebaseMessaging.swift
@@ -11,7 +11,6 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.tasks.await
-import skip.ui.__ // Don't import SkipUI directly because we don't need it in bridged API
 
 // https://firebase.google.com/docs/reference/swift/firebasemessaging/api/reference/Classes/Messaging
 // https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging


### PR DESCRIPTION
`SkipFirebaseAuth` and `SkipFirebaseMessaging` were configured to depend on SkipUI, but they don't use it and don't need it. `swift test` and `skip android build` succeeds on my machine on this PR.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

