### PR TITLE
Skip bridge gen for inline-reified decoded() (fixes #81)

### DIFF
--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -1097,8 +1097,10 @@ public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.Do
     // NOTE: use return-type inference on Android:
     //   let model: MyModel = try snapshot.decoded()
     // On iOS use FirebaseFirestoreSwift's data(as: MyModel.self) instead.
-    // SKIP @nobridge
-    // SKIP DECLARE: public inline fun <reified T : Decodable> decoded(): T
+    // @inline(__always) makes Skip emit a Kotlin `inline fun <reified T>`, so the
+    // body is inlined at the call site (no JVM-callable `decoded` method, no broken
+    // bridge JNI lookup) while staying reachable for native-Swift Android callers.
+    @inline(__always)
     public func decoded<T: Decodable>() throws -> T {
         guard let dict = data() else {
             throw NSError(domain: FirestoreErrorDomain, code: FirestoreErrorCode.notFound.rawValue, userInfo: [NSLocalizedDescriptionKey: "Document does not exist"])

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -1097,6 +1097,7 @@ public class DocumentSnapshot: KotlinConverting<com.google.firebase.firestore.Do
     // NOTE: use return-type inference on Android:
     //   let model: MyModel = try snapshot.decoded()
     // On iOS use FirebaseFirestoreSwift's data(as: MyModel.self) instead.
+    // SKIP @nobridge
     // SKIP DECLARE: public inline fun <reified T : Decodable> decoded(): T
     public func decoded<T: Decodable>() throws -> T {
         guard let dict = data() else {


### PR DESCRIPTION
Fixes #81.

`DocumentSnapshot.decoded()` was declared with `// SKIP DECLARE: public inline fun <reified T : Decodable> decoded(): T`, making the Kotlin signature inline-reified. Inline-reified functions are inlined at every call site, so the compiled `.class` exposes no callable `decoded` method — but the bridge generator still emitted a `getMethodID("decoded", "()Ljava/lang/Object;")!` JNI lookup. That force-unwrap traps native-Swift Android callers (non-`@bridge` app code) the moment the `DocumentSnapshot` class loads. Kotlin / `@bridge` callers inline the body and never look it up, which is why `swift test` didn't catch it.

### Fix

Drop the `// SKIP DECLARE` and mark `decoded()` with `@inline(__always)`. Per the [Skip docs](https://skip.dev/docs/swiftsupport/#reified-types), Skip converts any `@inline(__always)` Swift function into a Kotlin `inline fun <reified T>` automatically — same reified call-site inlining (so no broken JNI lookup is emitted), but standard Swift syntax instead of a hand-written declaration that can drift from the body, and `decoded()` stays reachable for native-Swift Android callers.

```swift
@inline(__always)
public func decoded<T: Decodable>() throws -> T { … }
```

(An earlier revision of this PR used `// SKIP @nobridge`, which fixed the crash but dropped `decoded()` from the bridge surface entirely. `@inline(__always)` is strictly better — thanks @marcprux.)

### Verification

- Transpiles clean (Swift → Kotlin) with the `@inline(__always)` form.
- Relying on CI to confirm the generated `SkipFirebaseFirestore_Bridge.swift` no longer emits the `decoded` JNI lookup.