### PR TITLE
Swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
 import Foundation
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ After [setting up](#setup) your app to use Firebase, enabling push notifications
 import SwiftFuseUI
 import SkipFirebaseMessaging
 
-final class NotificationDelegate : NSObject, UNUserNotificationCenterDelegate, Sendable {
+final class NotificationDelegate : NSObject, @preconcurrency UNUserNotificationCenterDelegate, Sendable {
     public func requestPermission() {
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         Task { @MainActor in
@@ -241,12 +241,14 @@ final class NotificationDelegate : NSObject, UNUserNotificationCenterDelegate, S
         }
     }
 
+    @MainActor
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         let content = notification.request.content
         logger.info("willPresentNotification: \(content.title): \(content.body) \(content.userInfo)")
         return [.banner, .sound]
     }
 
+    @MainActor
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
         let content = response.notification.request.content
         logger.info("didReceiveNotification: \(content.title): \(content.body) \(content.userInfo)")

--- a/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
+++ b/Sources/SkipFirebaseFirestore/SkipFirebaseFirestore.swift
@@ -3,6 +3,9 @@
 #if !SKIP_BRIDGE
 #if canImport(FirebaseFirestore)
 @_exported import FirebaseFirestore
+
+extension Firestore: @retroactive @unchecked Sendable {}
+extension CollectionReference: @retroactive @unchecked Sendable {}
 #elseif SKIP
 import Foundation
 import SkipFirebaseCore

--- a/Sources/SkipFirebaseMessaging/SkipFirebaseMessaging.swift
+++ b/Sources/SkipFirebaseMessaging/SkipFirebaseMessaging.swift
@@ -3,6 +3,8 @@
 #if !SKIP_BRIDGE
 #if canImport(FirebaseMessaging)
 @_exported import FirebaseMessaging
+
+extension Messaging: @retroactive @unchecked Sendable {}
 #elseif SKIP
 import Foundation
 import OSLog

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -5,8 +5,8 @@ import OSLog
 import Foundation
 
 #if !SKIP
-import FirebaseCore
-import FirebaseFirestore
+@preconcurrency import FirebaseCore
+@preconcurrency import FirebaseFirestore
 #else
 import SkipFirebaseCore
 import SkipFirebaseFirestore
@@ -23,7 +23,7 @@ let isRobolectric = isJava && !isAndroid
 /// True if the system's `Int` type is 32-bit.
 let is32BitInteger = Int64(Int.max) == Int64(Int32.max)
 
-var appName: String = "SkipFirebaseDemo"
+let appName: String = "SkipFirebaseDemo"
 
 // NOTE: we have @MainActor on SkipFirebaseFirestoreTests to force non-concurrent test execution in order to avoid errors like this:
 //

--- a/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/SkipFirebaseFirestoreTests.swift
@@ -4,13 +4,8 @@ import XCTest
 import OSLog
 import Foundation
 
-#if !SKIP
-@preconcurrency import FirebaseCore
-@preconcurrency import FirebaseFirestore
-#else
 import SkipFirebaseCore
 import SkipFirebaseFirestore
-#endif
 
 let logger: Logger = Logger(subsystem: "SkipFirebaseFirestoreTests", category: "Tests")
 


### PR DESCRIPTION
In https://github.com/skiptools/skipapp-fireside/pull/6 I fixed it by adding `@preconcurrency` to my `import SkipFirebaseMessaging` and `import SkipFirebaseFirestore` calls. In this PR, I'm adding `@retroactive @unchecked Sendable` conformance to `Messaging`, `Firestore`, and `CollectionReference`, so users don't have to do it themselves.

I'm also documenting how to use `@MainActor` on `NotificationDelegate` (it can crash the app if you don't add it).

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Tested in `skipapp-fireside`.