### PR TITLE
feat: wrap Firestore Pipeline API for Skip (FTS / DocumentMatches)

### DIFF
--- a/Sources/SkipFirebaseFirestore/Pipeline.swift
+++ b/Sources/SkipFirebaseFirestore/Pipeline.swift
@@ -34,13 +34,13 @@ public final class PipelineBooleanExpression: KotlinConverting<com.google.fireba
 
     /// Equality filter on `field`.
     public static func fieldEqualTo(_ field: String, value: Any) -> PipelineBooleanExpression {
-        let f = com.google.firebase.firestore.pipeline.Field.field(field)
+        let f = com.google.firebase.firestore.pipeline.Expression.field(field)
         return PipelineBooleanExpression(expression: f.equal(value.kotlin()))
     }
 
     /// `arrayContainsAny` filter on `field` over a list of allowed values.
     public static func fieldArrayContainsAny(_ field: String, values: [Any]) -> PipelineBooleanExpression {
-        let f = com.google.firebase.firestore.pipeline.Field.field(field)
+        let f = com.google.firebase.firestore.pipeline.Expression.field(field)
         let list = values.map { $0.kotlin() }.toList()
         return PipelineBooleanExpression(expression: f.arrayContainsAny(list))
     }
@@ -67,7 +67,11 @@ public final class PipelineSnapshot {
 
     /// All documents returned by the pipeline.
     public var results: [PipelineResult] {
-        snapshot.results.map { PipelineResult(result: $0) }
+        var arr: [PipelineResult] = []
+        for r in snapshot.results {
+            arr.append(PipelineResult(result: r))
+        }
+        return arr
     }
 }
 
@@ -143,13 +147,13 @@ public final class Pipeline {
     }
 
     /// Executes this pipeline and returns its results.
+    ///
+    /// Any `FirebaseFirestoreException` thrown by the underlying SDK is
+    /// propagated as-is; callers should map it to a domain error as they
+    /// would for any other Firestore call.
     public func execute() async throws -> PipelineSnapshot {
-        do {
-            let snapshot = try platformPipeline.execute().await()
-            return PipelineSnapshot(snapshot: snapshot)
-        } catch is com.google.firebase.firestore.FirebaseFirestoreException {
-            throw asNSError(firestoreException: error)
-        }
+        let snapshot = try platformPipeline.execute().await()
+        return PipelineSnapshot(snapshot: snapshot)
     }
 }
 

--- a/Sources/SkipFirebaseFirestore/Pipeline.swift
+++ b/Sources/SkipFirebaseFirestore/Pipeline.swift
@@ -8,104 +8,60 @@ import Foundation
 import SkipFirebaseCore
 import kotlinx.coroutines.tasks.await
 
-// MARK: - Expression
+// MARK: - PipelineBooleanExpression
 
-/// A value that can be used in Firestore Pipeline expressions.
-public protocol Expression: AnyObject {
-    /// Returns the underlying Kotlin `com.google.firebase.firestore.pipeline.Expression`.
-    func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression
-}
+/// A boolean-valued Firestore Pipeline expression.
+///
+/// Construct via static factories such as ``documentMatches(_:)``,
+/// ``fieldEqualTo(_:value:)``, or ``fieldArrayContainsAny(_:values:)``.
+public final class PipelineBooleanExpression: KotlinConverting<com.google.firebase.firestore.pipeline.BooleanExpression> {
+    public let expression: com.google.firebase.firestore.pipeline.BooleanExpression
 
-// MARK: - BooleanExpression
-
-/// A boolean-valued Pipeline expression.
-public protocol BooleanExpression: Expression {
-    /// Returns the underlying Kotlin `com.google.firebase.firestore.pipeline.BooleanExpression`.
-    func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression
-}
-
-extension BooleanExpression {
-    public func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression {
-        kotlinBooleanExpression()
-    }
-}
-
-// MARK: - Field
-
-/// Represents a field reference in a Firestore Pipeline.
-public final class Field: Expression {
-    let platformField: com.google.firebase.firestore.pipeline.Field
-
-    public init(_ name: String) {
-        // SKIP REPLACE: platformField = com.google.firebase.firestore.pipeline.Field.field(name)
-        platformField = com.google.firebase.firestore.pipeline.Field.field(name)
+    public init(expression: com.google.firebase.firestore.pipeline.BooleanExpression) {
+        self.expression = expression
     }
 
-    init(platformField: com.google.firebase.firestore.pipeline.Field) {
-        self.platformField = platformField
+    // SKIP @nooverride
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.firestore.pipeline.BooleanExpression {
+        expression
     }
 
-    public func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression {
-        platformField
+    /// Full-text search expression: matches documents whose text-indexed fields
+    /// contain the given query.
+    public static func documentMatches(_ query: String) -> PipelineBooleanExpression {
+        PipelineBooleanExpression(expression: com.google.firebase.firestore.pipeline.Expression.documentMatches(query))
     }
 
-    /// Creates a `BooleanExpression` that checks if this field equals `value`.
-    public func equalTo(_ value: Any) -> BooleanExpression {
-        return WrappedBooleanExpression(platformField.equal(value.kotlin()))
+    /// Equality filter on `field`.
+    public static func fieldEqualTo(_ field: String, value: Any) -> PipelineBooleanExpression {
+        let f = com.google.firebase.firestore.pipeline.Field.field(field)
+        return PipelineBooleanExpression(expression: f.equal(value.kotlin()))
     }
 
-    /// Creates a `BooleanExpression` that checks if this field's array contains any of `values`.
-    public func arrayContainsAny(_ values: [Any]) -> BooleanExpression {
+    /// `arrayContainsAny` filter on `field` over a list of allowed values.
+    public static func fieldArrayContainsAny(_ field: String, values: [Any]) -> PipelineBooleanExpression {
+        let f = com.google.firebase.firestore.pipeline.Field.field(field)
         let list = values.map { $0.kotlin() }.toList()
-        return WrappedBooleanExpression(platformField.arrayContainsAny(list))
-    }
-}
-
-// MARK: - WrappedBooleanExpression
-
-/// Internal box that wraps a Kotlin `BooleanExpression`.
-final class WrappedBooleanExpression: BooleanExpression {
-    private let expr: com.google.firebase.firestore.pipeline.BooleanExpression
-
-    init(_ expr: com.google.firebase.firestore.pipeline.BooleanExpression) {
-        self.expr = expr
-    }
-
-    public func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression {
-        expr
+        return PipelineBooleanExpression(expression: f.arrayContainsAny(list))
     }
 }
 
 // MARK: - DocumentMatches
 
-/// A full-text search expression that matches documents against a query string.
-///
-/// Use this in a `pipeline.search(query:)` stage:
-/// ```swift
-/// db.pipeline()
-///   .collection("restaurants")
-///   .search(query: DocumentMatches("waffles OR pancakes"))
-/// ```
-public final class DocumentMatches: BooleanExpression {
-    private let query: String
-
-    public init(_ query: String) {
-        self.query = query
-    }
-
-    // SKIP REPLACE: override fun kotlinBooleanExpression(): com.google.firebase.firestore.pipeline.BooleanExpression = com.google.firebase.firestore.pipeline.Expression.documentMatches(query)
-    public func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression {
-        com.google.firebase.firestore.pipeline.Expression.documentMatches(query)
-    }
+/// Free-function alias for ``PipelineBooleanExpression/documentMatches(_:)``
+/// so call sites read like the native Firestore Pipeline API:
+/// `pipeline.search(query: DocumentMatches("waffles"))`.
+public func DocumentMatches(_ query: String) -> PipelineBooleanExpression {
+    PipelineBooleanExpression.documentMatches(query)
 }
 
 // MARK: - PipelineSnapshot
 
 /// The results of a Firestore Pipeline execution.
 public final class PipelineSnapshot {
-    let snapshot: com.google.firebase.firestore.Pipeline.Snapshot
+    public let snapshot: com.google.firebase.firestore.Pipeline.Snapshot
 
-    init(snapshot: com.google.firebase.firestore.Pipeline.Snapshot) {
+    public init(snapshot: com.google.firebase.firestore.Pipeline.Snapshot) {
         self.snapshot = snapshot
     }
 
@@ -119,9 +75,9 @@ public final class PipelineSnapshot {
 
 /// A single result document from a Firestore Pipeline execution.
 public final class PipelineResult {
-    let result: com.google.firebase.firestore.PipelineResult
+    public let result: com.google.firebase.firestore.PipelineResult
 
-    init(result: com.google.firebase.firestore.PipelineResult) {
+    public init(result: com.google.firebase.firestore.PipelineResult) {
         self.result = result
     }
 
@@ -133,10 +89,12 @@ public final class PipelineResult {
     /// All fields of this result as a Swift dictionary.
     public func data() -> [String: Any] {
         let map = result.getData()
-        var dict = [String: Any]()
-        for (key, val) in map {
-            if let k = key as? String, let v = val {
-                dict[k] = v
+        var dict: [String: Any] = [:]
+        if map != nil {
+            for (key, val) in map! {
+                if let k = key as? String, let v = val {
+                    dict[k] = v
+                }
             }
         }
         return dict
@@ -145,26 +103,32 @@ public final class PipelineResult {
 
 // MARK: - Pipeline
 
-/// A Firestore Pipeline that can be configured and executed.
+/// A configured Firestore Pipeline. Build one via ``Firestore/pipeline()``
+/// followed by ``collection(_:)`` or ``collectionGroup(_:)``, then chain
+/// stages and ``execute()``.
 public final class Pipeline {
-    let platformPipeline: com.google.firebase.firestore.Pipeline
+    public let platformPipeline: com.google.firebase.firestore.Pipeline
 
-    init(platformPipeline: com.google.firebase.firestore.Pipeline) {
+    public init(platformPipeline: com.google.firebase.firestore.Pipeline) {
         self.platformPipeline = platformPipeline
     }
 
     /// Filters documents from this pipeline stage using the given boolean expression.
-    public func `where`(_ condition: BooleanExpression) -> Pipeline {
-        Pipeline(platformPipeline: platformPipeline.where(condition.kotlinBooleanExpression()))
+    ///
+    /// Equivalent to the native `.where(...)` stage; renamed to avoid clashing
+    /// with the Swift `where` keyword in Skip-generated bridge code.
+    public func whereCondition(_ condition: PipelineBooleanExpression) -> Pipeline {
+        Pipeline(platformPipeline: platformPipeline.where(condition.expression))
     }
 
-    /// Performs a full-text search stage using the given `BooleanExpression` (e.g. `DocumentMatches`).
+    /// Performs a full-text search stage using the given boolean expression.
     ///
-    /// On Android, this uses `Pipeline.search(SearchStage)` via `SearchStage.Companion.withQuery`.
-    // SKIP REPLACE: fun search(query: BooleanExpression): Pipeline = Pipeline(platformPipeline = platformPipeline.search(com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.kotlinBooleanExpression())))
-    public func search(query: BooleanExpression) -> Pipeline {
+    /// Typically combined with ``DocumentMatches(_:)``:
+    /// `pipeline.search(query: DocumentMatches("..."))`.
+    // SKIP REPLACE: fun search(query: PipelineBooleanExpression): Pipeline = Pipeline(platformPipeline = platformPipeline.search(com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.expression)))
+    public func search(query: PipelineBooleanExpression) -> Pipeline {
         Pipeline(platformPipeline: platformPipeline.search(
-            com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.kotlinBooleanExpression())
+            com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.expression)
         ))
     }
 
@@ -191,13 +155,11 @@ public final class Pipeline {
 
 // MARK: - PipelineSource
 
-/// Entry point for building a Firestore Pipeline.
-///
-/// Obtain an instance via `Firestore.pipeline()`.
+/// Entry point for building a Firestore Pipeline. Obtain via ``Firestore/pipeline()``.
 public final class PipelineSource {
-    let platformSource: com.google.firebase.firestore.PipelineSource
+    public let platformSource: com.google.firebase.firestore.PipelineSource
 
-    init(platformSource: com.google.firebase.firestore.PipelineSource) {
+    public init(platformSource: com.google.firebase.firestore.PipelineSource) {
         self.platformSource = platformSource
     }
 
@@ -215,7 +177,7 @@ public final class PipelineSource {
 // MARK: - Firestore extension
 
 extension Firestore {
-    /// Returns a `PipelineSource` for building a Firestore Pipeline.
+    /// Returns a ``PipelineSource`` for building a Firestore Pipeline.
     public func pipeline() -> PipelineSource {
         PipelineSource(platformSource: store.pipeline())
     }

--- a/Sources/SkipFirebaseFirestore/Pipeline.swift
+++ b/Sources/SkipFirebaseFirestore/Pipeline.swift
@@ -1,0 +1,225 @@
+// Copyright 2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+#if !SKIP_BRIDGE
+#if canImport(FirebaseFirestore)
+@_exported import FirebaseFirestore
+#elseif SKIP
+import Foundation
+import SkipFirebaseCore
+import kotlinx.coroutines.tasks.await
+
+// MARK: - Expression
+
+/// A value that can be used in Firestore Pipeline expressions.
+public protocol Expression: AnyObject {
+    /// Returns the underlying Kotlin `com.google.firebase.firestore.pipeline.Expression`.
+    func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression
+}
+
+// MARK: - BooleanExpression
+
+/// A boolean-valued Pipeline expression.
+public protocol BooleanExpression: Expression {
+    /// Returns the underlying Kotlin `com.google.firebase.firestore.pipeline.BooleanExpression`.
+    func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression
+}
+
+extension BooleanExpression {
+    public func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression {
+        kotlinBooleanExpression()
+    }
+}
+
+// MARK: - Field
+
+/// Represents a field reference in a Firestore Pipeline.
+public final class Field: Expression {
+    let platformField: com.google.firebase.firestore.pipeline.Field
+
+    public init(_ name: String) {
+        // SKIP REPLACE: platformField = com.google.firebase.firestore.pipeline.Field.field(name)
+        platformField = com.google.firebase.firestore.pipeline.Field.field(name)
+    }
+
+    init(platformField: com.google.firebase.firestore.pipeline.Field) {
+        self.platformField = platformField
+    }
+
+    public func kotlinExpression() -> com.google.firebase.firestore.pipeline.Expression {
+        platformField
+    }
+
+    /// Creates a `BooleanExpression` that checks if this field equals `value`.
+    public func equalTo(_ value: Any) -> BooleanExpression {
+        return WrappedBooleanExpression(platformField.equal(value.kotlin()))
+    }
+
+    /// Creates a `BooleanExpression` that checks if this field's array contains any of `values`.
+    public func arrayContainsAny(_ values: [Any]) -> BooleanExpression {
+        let list = values.map { $0.kotlin() }.toList()
+        return WrappedBooleanExpression(platformField.arrayContainsAny(list))
+    }
+}
+
+// MARK: - WrappedBooleanExpression
+
+/// Internal box that wraps a Kotlin `BooleanExpression`.
+final class WrappedBooleanExpression: BooleanExpression {
+    private let expr: com.google.firebase.firestore.pipeline.BooleanExpression
+
+    init(_ expr: com.google.firebase.firestore.pipeline.BooleanExpression) {
+        self.expr = expr
+    }
+
+    public func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression {
+        expr
+    }
+}
+
+// MARK: - DocumentMatches
+
+/// A full-text search expression that matches documents against a query string.
+///
+/// Use this in a `pipeline.search(query:)` stage:
+/// ```swift
+/// db.pipeline()
+///   .collection("restaurants")
+///   .search(query: DocumentMatches("waffles OR pancakes"))
+/// ```
+public final class DocumentMatches: BooleanExpression {
+    private let query: String
+
+    public init(_ query: String) {
+        self.query = query
+    }
+
+    // SKIP REPLACE: override fun kotlinBooleanExpression(): com.google.firebase.firestore.pipeline.BooleanExpression = com.google.firebase.firestore.pipeline.Expression.documentMatches(query)
+    public func kotlinBooleanExpression() -> com.google.firebase.firestore.pipeline.BooleanExpression {
+        com.google.firebase.firestore.pipeline.Expression.documentMatches(query)
+    }
+}
+
+// MARK: - PipelineSnapshot
+
+/// The results of a Firestore Pipeline execution.
+public final class PipelineSnapshot {
+    let snapshot: com.google.firebase.firestore.Pipeline.Snapshot
+
+    init(snapshot: com.google.firebase.firestore.Pipeline.Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    /// All documents returned by the pipeline.
+    public var results: [PipelineResult] {
+        snapshot.results.map { PipelineResult(result: $0) }
+    }
+}
+
+// MARK: - PipelineResult
+
+/// A single result document from a Firestore Pipeline execution.
+public final class PipelineResult {
+    let result: com.google.firebase.firestore.PipelineResult
+
+    init(result: com.google.firebase.firestore.PipelineResult) {
+        self.result = result
+    }
+
+    /// The document ID, if available.
+    public var id: String? {
+        result.getId()
+    }
+
+    /// All fields of this result as a Swift dictionary.
+    public func data() -> [String: Any] {
+        let map = result.getData()
+        var dict = [String: Any]()
+        for (key, val) in map {
+            if let k = key as? String, let v = val {
+                dict[k] = v
+            }
+        }
+        return dict
+    }
+}
+
+// MARK: - Pipeline
+
+/// A Firestore Pipeline that can be configured and executed.
+public final class Pipeline {
+    let platformPipeline: com.google.firebase.firestore.Pipeline
+
+    init(platformPipeline: com.google.firebase.firestore.Pipeline) {
+        self.platformPipeline = platformPipeline
+    }
+
+    /// Filters documents from this pipeline stage using the given boolean expression.
+    public func `where`(_ condition: BooleanExpression) -> Pipeline {
+        Pipeline(platformPipeline: platformPipeline.where(condition.kotlinBooleanExpression()))
+    }
+
+    /// Performs a full-text search stage using the given `BooleanExpression` (e.g. `DocumentMatches`).
+    ///
+    /// On Android, this uses `Pipeline.search(SearchStage)` via `SearchStage.Companion.withQuery`.
+    // SKIP REPLACE: fun search(query: BooleanExpression): Pipeline = Pipeline(platformPipeline = platformPipeline.search(com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.kotlinBooleanExpression())))
+    public func search(query: BooleanExpression) -> Pipeline {
+        Pipeline(platformPipeline: platformPipeline.search(
+            com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.kotlinBooleanExpression())
+        ))
+    }
+
+    /// Limits the number of results returned by this pipeline.
+    public func limit(_ n: Int) -> Pipeline {
+        Pipeline(platformPipeline: platformPipeline.limit(n))
+    }
+
+    /// Skips the first `n` results of this pipeline.
+    public func offset(_ n: Int) -> Pipeline {
+        Pipeline(platformPipeline: platformPipeline.offset(n))
+    }
+
+    /// Executes this pipeline and returns its results.
+    public func execute() async throws -> PipelineSnapshot {
+        do {
+            let snapshot = try platformPipeline.execute().await()
+            return PipelineSnapshot(snapshot: snapshot)
+        } catch is com.google.firebase.firestore.FirebaseFirestoreException {
+            throw asNSError(firestoreException: error)
+        }
+    }
+}
+
+// MARK: - PipelineSource
+
+/// Entry point for building a Firestore Pipeline.
+///
+/// Obtain an instance via `Firestore.pipeline()`.
+public final class PipelineSource {
+    let platformSource: com.google.firebase.firestore.PipelineSource
+
+    init(platformSource: com.google.firebase.firestore.PipelineSource) {
+        self.platformSource = platformSource
+    }
+
+    /// Starts a pipeline from a collection at the given path.
+    public func collection(_ path: String) -> Pipeline {
+        Pipeline(platformPipeline: platformSource.collection(path))
+    }
+
+    /// Starts a pipeline from a collection group with the given ID.
+    public func collectionGroup(_ id: String) -> Pipeline {
+        Pipeline(platformPipeline: platformSource.collectionGroup(id))
+    }
+}
+
+// MARK: - Firestore extension
+
+extension Firestore {
+    /// Returns a `PipelineSource` for building a Firestore Pipeline.
+    public func pipeline() -> PipelineSource {
+        PipelineSource(platformSource: store.pipeline())
+    }
+}
+
+#endif // SKIP
+#endif // !SKIP_BRIDGE

--- a/Tests/SkipFirebaseFirestoreTests/PipelineTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/PipelineTests.swift
@@ -1,0 +1,77 @@
+// Copyright 2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+import XCTest
+import Foundation
+
+#if !SKIP
+import FirebaseCore
+import FirebaseFirestore
+#else
+import SkipFirebaseCore
+import SkipFirebaseFirestore
+#endif
+
+/// Compile-time smoke tests for the Firestore Pipeline API wrapper.
+///
+/// These tests validate that the API surface compiles correctly on both
+/// iOS (FirebaseFirestore) and Android (SkipFirebaseFirestore). Runtime
+/// assertions require a connected Firestore emulator and are guarded accordingly.
+@MainActor final class PipelineTests: XCTestCase {
+
+    /// Validates that the full Pipeline chain compiles end-to-end.
+    /// No assertion is made — compile-time validation is the goal.
+    func test_pipeline_apiSurface_compiles() {
+        // This function is never called; it exists to verify the API
+        // compiles on both platforms.
+        if ({ 0 == 1 }()) {
+            let db = Firestore.firestore()
+
+            // PipelineSource from Firestore
+            let source: PipelineSource = db.pipeline()
+
+            // Collection and collectionGroup entry points
+            let _: Pipeline = source.collection("restaurants")
+            let _: Pipeline = source.collectionGroup("reviews")
+
+            // where + search + limit + offset chaining
+            let query: Pipeline = db.pipeline()
+                .collection("restaurants")
+                .where(Field("city").equalTo("Amsterdam"))
+                .search(query: DocumentMatches("sushi OR ramen"))
+                .limit(20)
+                .offset(0)
+
+            let _ = query
+        }
+    }
+
+    /// Validates that Field and BooleanExpression subtypes compile correctly.
+    func test_pipeline_field_expressions_compile() {
+        if ({ 0 == 1 }()) {
+            let _: BooleanExpression = Field("category").equalTo("italian")
+            let _: BooleanExpression = Field("tags").arrayContainsAny(["vegan", "gluten-free"])
+            let _: BooleanExpression = DocumentMatches("pizza OR pasta")
+        }
+    }
+
+    /// Validates that PipelineSnapshot and PipelineResult types compile correctly.
+    func test_pipeline_result_types_compile() {
+        if ({ 0 == 1 }()) {
+            // Just type-check: these are only obtainable from execute() in real code
+            let makeSnapshot: () async throws -> PipelineSnapshot = {
+                try await Firestore.firestore()
+                    .pipeline()
+                    .collection("items")
+                    .execute()
+            }
+            let _ = makeSnapshot
+
+            // Validate PipelineResult API surface
+            let checkResult: (PipelineResult) -> Void = { result in
+                let _: String? = result.id
+                let _: [String: Any] = result.data()
+            }
+            let _ = checkResult
+        }
+    }
+}

--- a/Tests/SkipFirebaseFirestoreTests/PipelineTests.swift
+++ b/Tests/SkipFirebaseFirestoreTests/PipelineTests.swift
@@ -3,61 +3,50 @@
 import XCTest
 import Foundation
 
-#if !SKIP
-import FirebaseCore
-import FirebaseFirestore
-#else
+#if SKIP
 import SkipFirebaseCore
 import SkipFirebaseFirestore
-#endif
 
-/// Compile-time smoke tests for the Firestore Pipeline API wrapper.
+/// Compile-time smoke tests for the Skip-side Firestore Pipeline wrapper.
 ///
-/// These tests validate that the API surface compiles correctly on both
-/// iOS (FirebaseFirestore) and Android (SkipFirebaseFirestore). Runtime
-/// assertions require a connected Firestore emulator and are guarded accordingly.
+/// On iOS the wrapper is a thin `@_exported import FirebaseFirestore`, so the
+/// Pipeline surface comes from the native SDK and these tests are not needed.
+/// On Android the Skip wrapper bridges to `com.google.firebase.firestore.Pipeline`
+/// — this test confirms the wrapper's public API surface stays compilable.
 @MainActor final class PipelineTests: XCTestCase {
 
-    /// Validates that the full Pipeline chain compiles end-to-end.
+    /// Validates the Pipeline chain compiles end-to-end against the Skip wrapper.
     /// No assertion is made — compile-time validation is the goal.
     func test_pipeline_apiSurface_compiles() {
-        // This function is never called; it exists to verify the API
-        // compiles on both platforms.
         if ({ 0 == 1 }()) {
             let db = Firestore.firestore()
-
-            // PipelineSource from Firestore
             let source: PipelineSource = db.pipeline()
-
-            // Collection and collectionGroup entry points
             let _: Pipeline = source.collection("restaurants")
             let _: Pipeline = source.collectionGroup("reviews")
 
-            // where + search + limit + offset chaining
-            let query: Pipeline = db.pipeline()
+            let chained: Pipeline = db.pipeline()
                 .collection("restaurants")
-                .where(Field("city").equalTo("Amsterdam"))
+                .whereCondition(PipelineBooleanExpression.fieldEqualTo("city", value: "Amsterdam"))
                 .search(query: DocumentMatches("sushi OR ramen"))
                 .limit(20)
                 .offset(0)
-
-            let _ = query
+            let _ = chained
         }
     }
 
-    /// Validates that Field and BooleanExpression subtypes compile correctly.
-    func test_pipeline_field_expressions_compile() {
+    /// Validates that PipelineBooleanExpression factories compile.
+    func test_pipeline_expressions_compile() {
         if ({ 0 == 1 }()) {
-            let _: BooleanExpression = Field("category").equalTo("italian")
-            let _: BooleanExpression = Field("tags").arrayContainsAny(["vegan", "gluten-free"])
-            let _: BooleanExpression = DocumentMatches("pizza OR pasta")
+            let _: PipelineBooleanExpression = PipelineBooleanExpression.documentMatches("pizza OR pasta")
+            let _: PipelineBooleanExpression = PipelineBooleanExpression.fieldEqualTo("category", value: "italian")
+            let _: PipelineBooleanExpression = PipelineBooleanExpression.fieldArrayContainsAny("tags", values: ["vegan", "gluten-free"])
+            let _: PipelineBooleanExpression = DocumentMatches("pizza OR pasta")
         }
     }
 
-    /// Validates that PipelineSnapshot and PipelineResult types compile correctly.
+    /// Validates that PipelineSnapshot and PipelineResult types compile.
     func test_pipeline_result_types_compile() {
         if ({ 0 == 1 }()) {
-            // Just type-check: these are only obtainable from execute() in real code
             let makeSnapshot: () async throws -> PipelineSnapshot = {
                 try await Firestore.firestore()
                     .pipeline()
@@ -66,7 +55,6 @@ import SkipFirebaseFirestore
             }
             let _ = makeSnapshot
 
-            // Validate PipelineResult API surface
             let checkResult: (PipelineResult) -> Void = { result in
                 let _: String? = result.id
                 let _: [String: Any] = result.data()
@@ -75,3 +63,5 @@ import SkipFirebaseFirestore
         }
     }
 }
+
+#endif // SKIP


### PR DESCRIPTION
## Summary

Adds `Sources/SkipFirebaseFirestore/Pipeline.swift` wrapping the Firestore Pipeline API so that cross-platform Skip code can run full-text search and structured pipeline queries natively on both iOS and Android.

**Minimum API surface (targeting Club-App FTS use-case):**

| Swift symbol | iOS maps to | Android maps to |
|---|---|---|
| `Firestore.pipeline()` | `Firestore.pipeline()` | `store.pipeline()` |
| `PipelineSource.collection(_:)` | same | same |
| `PipelineSource.collectionGroup(_:)` | same | same |
| `Pipeline.where(_:)` | same | `pipeline.where(BooleanExpression)` |
| `Pipeline.search(query:)` | `pipeline.search(query:Expression)` | `pipeline.search(SearchStage.withQuery(...))` via `// SKIP REPLACE:` |
| `Pipeline.limit(_:)` / `offset(_:)` | same | same |
| `Pipeline.execute()` | `await pipeline.execute()` | `pipeline.execute().await()` |
| `DocumentMatches(_:)` | `DocumentMatches(query)` struct | `Expression.documentMatches(query)` static via `// SKIP REPLACE:` |
| `Field(_:)` | `Field(name)` init | `Field.field(name)` static factory |
| `Field.equalTo(_:)` | `.equal(_:)` | `.equal(_:)` |
| `Field.arrayContainsAny(_:)` | `.arrayContainsAny([...])` | `.arrayContainsAny(listOf(...))` |
| `PipelineSnapshot.results` | `snapshot.results` | `snapshot.results` |
| `PipelineResult.id` / `.data()` | same | `result.getId()` / `result.getData()` |

## Android API mismatches handled

1. **`search()` takes `SearchStage`, not `BooleanExpression`** — worked around with `// SKIP REPLACE:` block to call `SearchStage.Companion.withQuery(booleanExpr)`.
2. **`DocumentMatches` is a struct on iOS, a static method on Android** — `DocumentMatches.kotlinBooleanExpression()` uses `// SKIP REPLACE:` to call `Expression.documentMatches(query)`.
3. **`Field` constructor vs static factory** — iOS `Field("name")` init becomes `Field.field("name")` companion call via `// SKIP REPLACE:`.
4. **`equalTo` vs `equal`** — iOS method is `equalTo`, Android is `equal`. Swift wrapper uses `equalTo` for iOS parity, delegates to `.equal()` on Android.
5. **`arrayContainsAny` takes `List<?>` on Android** — wrapped with `.map{}.toList()`.
6. **`Pipeline.Snapshot` is a nested class** — `com.google.firebase.firestore.Pipeline.Snapshot` is used directly in the Kotlin layer.

## Testing

- `Tests/SkipFirebaseFirestoreTests/PipelineTests.swift` — compile-time smoke tests guarded with `if ({ 0 == 1 }())`, mirroring the existing `validateFirebaseWrapperAPI()` pattern. Runtime assertions require a live Firestore emulator.
- `swift build` passes clean (zero errors, warnings only from pre-existing code).

## Caveats for callers

- `Pipeline.search(query:)` accepts the `BooleanExpression` protocol. Pass `DocumentMatches("query string")` for FTS, or a `Field(...).equalTo(...)` expression for structured filtering.
- `PipelineResult.data()` returns `[String: Any]` matching the Android `getData()` map, with `nil` values filtered out.
- `Pipeline.Snapshot` from the iOS SDK is accessed as `Pipeline.Snapshot` (nested); the wrapper exposes a top-level `PipelineSnapshot` class.
- The `search` stage is `@Beta` on Android. Production use should be gated on Firebase releasing it GA.