### PR TITLE
Make HTTPSCallableResult Sendable to fix Swift 6 bridge data-race error

### DIFF
--- a/Sources/SkipFirebaseFunctions/SkipFirebaseFunctions.swift
+++ b/Sources/SkipFirebaseFunctions/SkipFirebaseFunctions.swift
@@ -3,6 +3,8 @@
 #if !SKIP_BRIDGE
 #if canImport(FirebaseFunctions)
 @_exported import FirebaseFunctions
+
+extension HTTPSCallableResult: @retroactive @unchecked Sendable {}
 #elseif SKIP
 import Foundation
 import SkipFirebaseCore


### PR DESCRIPTION
## Summary

Fixes #92.

Since 0.20.0 bumped `swift-tools-version` to 6.1, the package and its skipstone-generated `*_Bridge.swift` files compile in **Swift 6 language mode**, where strict-concurrency violations are hard errors. The generated `SkipFirebaseFunctions` bridge resumes its continuation with the call result:

```
SkipFirebaseFunctions_Bridge.swift:253:36: error: sending 'f_return' risks causing data races [#SendingRisksDataRace]
253 |                     f_continuation.resume(returning: f_return!)
    |                                    |- error: sending 'f_return' risks causing data races
```

`resume(returning:)` takes a `sending` parameter under Swift 6, but the re-exported `FirebaseFunctions.HTTPSCallableResult` is not `Sendable`, so passing it across the task-isolation boundary is rejected. This compiled fine under 0.19.0 (tools-version 5.9, where it was at most a warning).

## Change

Add a retroactive `@unchecked Sendable` conformance for `HTTPSCallableResult`, mirroring the exact pattern 0.20.0 already applied to `Firestore`, `CollectionReference` and `Messaging` — Functions was simply missed.

```swift
extension HTTPSCallableResult: @retroactive @unchecked Sendable {}
```

## Verification

`swift build --target SkipFirebaseFunctions` (Darwin) compiles clean; the generated functions bridge no longer raises `#SendingRisksDataRace`.