### PR TITLE
Fix: Pipeline.search() missing from generated SkipBridge peer

### DIFF
--- a/Sources/SkipFirebaseFirestore/Pipeline.swift
+++ b/Sources/SkipFirebaseFirestore/Pipeline.swift
@@ -129,7 +129,13 @@ public final class Pipeline {
     ///
     /// Typically combined with ``DocumentMatches(_:)``:
     /// `pipeline.search(query: DocumentMatches("..."))`.
-    // SKIP REPLACE: fun search(query: PipelineBooleanExpression): Pipeline = Pipeline(platformPipeline = platformPipeline.search(com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.expression)))
+    ///
+    /// No `// SKIP REPLACE:` override here on purpose: the body below already
+    /// transpiles to equivalent Kotlin via direct interop, and a `SKIP REPLACE`
+    /// override on this method causes SkipBridge to silently omit `search`
+    /// from the generated Swift bridge peer (`Pipeline_Bridge.swift`) even
+    /// though the Kotlin transpile output is correct — `limit`/`offset`/
+    /// `whereCondition`, which have no override, bridge fine.
     public func search(query: PipelineBooleanExpression) -> Pipeline {
         Pipeline(platformPipeline: platformPipeline.search(
             com.google.firebase.firestore.pipeline.SearchStage.withQuery(query.expression)


### PR DESCRIPTION
## Summary
- `Pipeline.search(query:)` carried a `// SKIP REPLACE:` comment whose Kotlin is functionally identical to what the naive Swift→Kotlin transpile already produces.
- That override causes SkipBridge to silently drop `search` from the generated Swift bridge peer (`Pipeline_Bridge.swift`) used by `SKIP_BRIDGE`-flagged consumer builds (e.g. an app targeting Android), even though the Kotlin transpile output is correct and identical with or without the override.
- `limit(_:)`, `offset(_:)`, and `whereCondition(_:)` — which have no `SKIP REPLACE` override — bridge correctly and were used to confirm the pattern.
- Removing the override restores bridge visibility for `search` while leaving the transpiled Kotlin byte-for-byte identical (verified locally).

## Consumer-side symptom
Building a Skip app for Android hits:
```
error: value of type 'Pipeline' has no member 'search'
```
during the `SKIP_BRIDGE`-flagged `swift build --swift-sdk aarch64-unknown-linux-android28 ...` pass, despite `Firestore Enterprise` Pipeline FTS working correctly on iOS and the Kotlin transpile compiling fine.

## Test plan
- [x] `swift build --product SkipFirebaseFirestore` succeeds (iOS/macOS side).
- [x] Diffed the transpiled `Pipeline.kt` output before/after removing the override — byte-identical `search` implementation.
- [ ] Verified against a real `SKIP_BRIDGE` Android build in the downstream consumer app (Club-App) — in progress, will confirm once this lands.