### PR TITLE
feat(storage): expose maxUploadRetryTime / maxDownloadRetryTime / maxOperationRetryTime on Storage

### DIFF
--- a/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
+++ b/Sources/SkipFirebaseStorage/SkipFirebaseStorage.swift
@@ -39,6 +39,27 @@ public final class Storage {
         FirebaseApp(app: platformValue.getApp())
     }
 
+    /// Maximum time in seconds to retry an upload if a failure occurs.
+    /// Defaults to 10 minutes (600 seconds).
+    public var maxUploadRetryTime: TimeInterval {
+        get { TimeInterval(platformValue.getMaxUploadRetryTimeMillis()) / 1000.0 }
+        set { platformValue.setMaxUploadRetryTimeMillis(Int64(newValue * 1000.0)) }
+    }
+
+    /// Maximum time in seconds to retry a download if a failure occurs.
+    /// Defaults to 10 minutes (600 seconds).
+    public var maxDownloadRetryTime: TimeInterval {
+        get { TimeInterval(platformValue.getMaxDownloadRetryTimeMillis()) / 1000.0 }
+        set { platformValue.setMaxDownloadRetryTimeMillis(Int64(newValue * 1000.0)) }
+    }
+
+    /// Maximum time in seconds to retry operations other than upload and download if a failure occurs.
+    /// Defaults to 2 minutes (120 seconds).
+    public var maxOperationRetryTime: TimeInterval {
+        get { TimeInterval(platformValue.getMaxOperationRetryTimeMillis()) / 1000.0 }
+        set { platformValue.setMaxOperationRetryTimeMillis(Int64(newValue * 1000.0)) }
+    }
+
     public func reference() -> StorageReference {
         return StorageReference(platformValue.reference)
     }

--- a/Tests/SkipFirebaseStorageTests/SkipFirebaseStorageTests.swift
+++ b/Tests/SkipFirebaseStorageTests/SkipFirebaseStorageTests.swift
@@ -36,6 +36,14 @@ let logger: Logger = Logger(subsystem: "SkipFirebaseStorageTests", category: "Te
             let storageCustomURL = Storage.storage(url: "gs://")
 
             let storage = Storage.storage()
+
+            storage.maxUploadRetryTime = 60.0
+            storage.maxDownloadRetryTime = 60.0
+            storage.maxOperationRetryTime = 60.0
+            let _: TimeInterval = storage.maxUploadRetryTime
+            let _: TimeInterval = storage.maxDownloadRetryTime
+            let _: TimeInterval = storage.maxOperationRetryTime
+
             let ref: StorageReference = storage.reference()
             let _: StorageReference = storage.reference(withPath: "test")
             let _: StorageReference = storage.reference(forURL: "https://firebase.google.com/")


### PR DESCRIPTION
## Summary

Exposes the three retry-deadline properties of `Storage` in `SkipFirebaseStorage`, matching the Firebase iOS SDK API:

- `maxUploadRetryTime: TimeInterval`
- `maxDownloadRetryTime: TimeInterval`
- `maxOperationRetryTime: TimeInterval`

All three are seconds-based (`TimeInterval`), exactly like [their iOS counterparts](https://firebase.google.com/docs/reference/swift/firebasestorage/api/reference/Classes/Storage), and map to the Android SDK's millisecond accessors (`get`/`setMaxDownloadRetryTimeMillis(long)` etc. on [`FirebaseStorage`](https://firebase.google.com/docs/reference/android/com/google/firebase/storage/FirebaseStorage)).

## Motivation

With no network, a Firebase Storage download on Android does not fail fast — it silently retries for the full `maxDownloadRetryTime` (default **10 minutes**, measured on device) before throwing `StorageException: The operation retry limit has been exceeded`. On iOS, apps commonly bound this with `storage.maxDownloadRetryTime = 20`; the Skip wrapper had no way to do the same, so identical shared Swift code could not control the retry window on Android.

With this change, the same line of Swift works on both platforms:

```swift
let storage = Storage.storage()
storage.maxDownloadRetryTime = 20 // seconds, both platforms
```

## Testing

- `Storage` API-shape checks added alongside the existing ones in `SkipFirebaseStorageTests`.
- Verified on an Android emulator (API 36) via a bridged app build: with the device offline and `maxDownloadRetryTime = 20`, a `getDataAsync` download fails after ~20s instead of the 10-minute default; getter round-trips the value.
