### PR TITLE
Add User.providerData and sendEmailVerification(beforeUpdatingEmail:)

### DIFF
--- a/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
+++ b/Sources/SkipFirebaseAuth/SkipFirebaseAuth.swift
@@ -291,6 +291,22 @@ public class User: Equatable, KotlinConverting<com.google.firebase.auth.Firebase
         UserMetadata(platformValue.metadata)
     }
 
+    /// The identity providers linked to this account, in the order Firebase
+    /// returns them.
+    ///
+    /// Android additionally reports a synthetic `"firebase"` entry that iOS does
+    /// not; it is filtered out so `providerData.first?.providerID` means the same
+    /// thing on both platforms.
+    /// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#getProviderData()
+    public var providerData: [UserInfo] {
+        var infos: [UserInfo] = []
+        for info in platformValue.providerData {
+            if info.providerId == com.google.firebase.auth.FirebaseAuthProvider.PROVIDER_ID { continue }
+            infos.append(UserInfo(info))
+        }
+        return infos
+    }
+
     public func createProfileChangeRequest() -> UserProfileChangeRequest {
         return UserProfileChangeRequest(self)
     }
@@ -302,6 +318,14 @@ public class User: Equatable, KotlinConverting<com.google.firebase.auth.Firebase
         platformValue.sendEmailVerification().await()
     }
     
+    /// Sends a verification link to `email`; the account's address only changes
+    /// once the user follows it. Matches iOS
+    /// `sendEmailVerification(beforeUpdatingEmail:)`.
+    /// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#verifyBeforeUpdateEmail(java.lang.String)
+    public func sendEmailVerification(beforeUpdatingEmail email: String) async throws {
+        platformValue.verifyBeforeUpdateEmail(email).await()
+    }
+
     /// Throws `FirebaseAuthInvalidUserException`/`FirebaseAuthRecentLoginRequiredException`
     /// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser#reauthenticate(com.google.firebase.auth.AuthCredential)
     public func reauthenticate(with credential: AuthCredential) async throws {
@@ -367,6 +391,46 @@ public class User: Equatable, KotlinConverting<com.google.firebase.auth.Firebase
             ])
         }
         return token
+    }
+}
+
+/// A single identity provider entry from `User.providerData`.
+/// https://firebase.google.com/docs/reference/android/com/google/firebase/auth/UserInfo
+public class UserInfo: KotlinConverting<com.google.firebase.auth.UserInfo> {
+    public let platformValue: com.google.firebase.auth.UserInfo
+
+    public init(_ platformValue: com.google.firebase.auth.UserInfo) {
+        self.platformValue = platformValue
+    }
+
+    // SKIP @nooverride
+    public override func kotlin(nocopy: Bool = false) -> com.google.firebase.auth.UserInfo {
+        platformValue
+    }
+
+    public var providerID: String {
+        platformValue.providerId
+    }
+
+    public var uid: String {
+        platformValue.uid
+    }
+
+    public var displayName: String? {
+        platformValue.displayName
+    }
+
+    public var email: String? {
+        platformValue.email
+    }
+
+    public var phoneNumber: String? {
+        platformValue.phoneNumber
+    }
+
+    public var photoURL: URL? {
+        guard let uri = platformValue.photoUrl else { return nil }
+        return URL(string: uri.toString())
     }
 }
 

--- a/Tests/SkipFirebaseAuthTests/SkipFirebaseAuthTests.swift
+++ b/Tests/SkipFirebaseAuthTests/SkipFirebaseAuthTests.swift
@@ -23,6 +23,12 @@ let logger: Logger = Logger(subsystem: "SkipBase", category: "Tests")
                 let signIn = try await auth.signInAnonymously()
                 XCTAssertNotNil(signIn.user.metadata.creationDate)
                 XCTAssertNotNil(signIn.user.metadata.lastSignInDate)
+                // Shape parity with iOS FirebaseAuth: `providerData` is a list of
+                // `UserInfo` carrying `providerID`, and the pre-change email
+                // verification takes the new address.
+                let providers: [String] = signIn.user.providerData.map { $0.providerID }
+                XCTAssertNotNil(providers)
+                try await signIn.user.sendEmailVerification(beforeUpdatingEmail: "new@example.org")
             } catch {
             }
             auth.removeStateDidChangeListener(listener)


### PR DESCRIPTION
Two `FirebaseUser` APIs that iOS callers rely on have no Android counterpart, so cross-platform code has to fall back to `platformValue` — which is opaque in the `SKIP_BRIDGE` pass and therefore unreachable from a natively compiled app.

- `User.providerData: [UserInfo]` wraps `FirebaseUser.getProviderData()`. The new `UserInfo` class exposes `providerID`/`uid`/`displayName`/`email`/`phoneNumber`/`photoURL`. Android's synthetic `"firebase"` provider entry is filtered out so `providerData.first?.providerID` means the same thing on both platforms.
- `User.sendEmailVerification(beforeUpdatingEmail:)` wraps `FirebaseUser.verifyBeforeUpdateEmail()`, matching the iOS selector.

Verification

- `swift build --build-tests` is green, i.e. the two new API shapes in `SkipFirebaseAuthTests` compile against the **real Apple FirebaseAuth SDK** — that is what pins the signatures to iOS.
- Exercised on an Android 16 emulator against a real Firebase project: reading the sign-in provider of a password account, and a full change-email round trip (re-authenticate, then send the verification link to the new address).